### PR TITLE
Add authentication tests for tasks (normal & abnormal cases)

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,2 +1,18 @@
 class ApplicationController < ActionController::API
+    include ActionController::MimeResponds # APIモード用のコントローラ
+
+    # 未ログイン時はリダイレクトではなく401を返すように設定
+    before_action :configure_permitted_parameters, if: :devise_controller?
+
+    protected
+
+    # 未ログイン時の共通処理
+    def authenticate_user!(opts = {})
+        unless user_signed_in? # Deviseが提供するヘルパー。ログインしているか確認
+            # ログインしていなければ401エラーを返す(API用)
+            render json: { errors: ["You need to sign in or sign up before continuing."] },
+                   status: :unauthorized and return
+        end
+        super # ログイン済みなら、Devise標準のauthenticate_user!を実行
+    end
 end

--- a/backend/app/controllers/tasks_controller.rb
+++ b/backend/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 class TasksController < ApplicationController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
     before_action :set_task, only: [:show, :update, :destroy]
-  
+
     def index
       if params[:user_id]
         @tasks = Task.where(user_id: params[:user_id])
@@ -13,18 +14,18 @@ class TasksController < ApplicationController
     def show
       render json: @task
     end
-  
+
     def create
       @task = Task.new(task_params)
       @task.user = current_user
-  
+
       if @task.save
         render json: @task, status: :created
       else
         render json: { errors: @task.errors.full_messages }, status: :unprocessable_entity
       end
     end
-  
+
     def update
       if @task.update(task_params)
         render json: @task, status: :ok

--- a/backend/spec/requests/tasks_spec.rb
+++ b/backend/spec/requests/tasks_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Task API", type: :request do
         it "タスク一覧を取得できる" do
             # テストデータ作成
             user = User.create!(email: "test@example.com", password: "password")
+
             Task.create!(title: "テストタスク1", status: :not_started, user: user)
             Task.create!(title: "テストタスク2", status: :in_progress, user: user)
 
@@ -32,26 +33,16 @@ RSpec.describe "Task API", type: :request do
             Task.create!(title: "user1のタスク2", status: :completed, user: user1)
             Task.create!(title: "user2のタスク", status: :in_progress, user: user2)
 
-            # user1のタスクだけ取得するようにAPIリクエストを送る
-            get "/tasks", params: { user_id: user1.id }
+            get "/tasks", params: { user_id: user1.id } # user1のタスクだけ取得するようにAPIリクエストを送る
 
-            # HTTPステータスが200(OK)であることを確認
-            expect(response).to have_http_status(:ok)
+            expect(response).to have_http_status(:ok) # HTTPステータスが200(OK)であることを確認
 
-            # JSONレスポンスをパースして配列化
-            json = JSON.parse(response.body)
+            json = JSON.parse(response.body) # JSONレスポンスをパースして配列化
+            expect(json.size).to eq(2) # 取得したタスク数が２件だけであることを確認
+            titles = json.map { |task| task["title"]} # タスクのタイトル一覧を配列に抽出
+            expect(titles).to include("user1のタスク1", "user1のタスク2") # user1のタスクが含まれていることを確認
 
-            # 取得したタスク数が２件だけであることを確認
-            expect(json.size).to eq(2)
-
-            # タスクのタイトル一覧を配列に抽出
-            titles = json.map { |task| task["title"]}
-
-            # user1のタスクが含まれていることを確認
-            expect(titles).to include("user1のタスク1", "user1のタスク2")
-
-            # user2のタスクが含まれていないことを確認
-            expect(titles).not_to include("user2のタスク")
+            expect(titles).not_to include("user2のタスク") # user2のタスクが含まれていないことを確認
         end
     end
 
@@ -78,6 +69,7 @@ RSpec.describe "Task API", type: :request do
         it "タイトルが空なら422を返す" do
             # テスト用ユーザーを作成
             user = User.create!(email: "test@example.com", password: "password")
+            sign_in user
 
             # APIにタスク作成リクエストを送信 (タイトルが空)
             post "/tasks", params: {
@@ -91,19 +83,34 @@ RSpec.describe "Task API", type: :request do
             # HTTPステータスコードの確認
             # コントローラ側で422を返すように実装している前提
             expect(response).to have_http_status(:unprocessable_entity)
-
-            # レスポンスのJSONをパース
-            json = JSON.parse(response.body)
-
+            json = JSON.parse(response.body) # レスポンスのJSONをパース
             # エラーメッセージがレスポンスに含まれているか確認
             expect(json["errors"]).to include("Title can't be blank")
         end
     end
 
+    # POST /tasks (認証必須)
+    describe "POST /tasks (認証必須)" do
+        it "未ログインの場合401を返す" do
+            # ログインせずにタスク作成APIを叩く
+            post "/tasks", params: {
+                task: {
+                    title: "未ログインタスク",
+                    status: :not_started,
+                    user_id: 1 # 指定しているが認証必須なので無視される想定
+                }
+            }
+
+            expect(response).to have_http_status(:unauthorized)
+            json = JSON.parse(response.body)
+            expect(json["errors"]).to include("You need to sign in or sign up before continuing.")
+        end
+    end
 
     describe "PATCH /tasks/:id" do
         it "タスクを更新できる" do
             user = User.create!(email: "test3@example.com", password: "password")
+            sign_in user
             task = Task.create!(title: "更新前タスク", status: :not_started, user: user)
 
             patch "/tasks/#{task.id}", params: { task: { title: "更新後タスク" } }
@@ -117,6 +124,8 @@ RSpec.describe "Task API", type: :request do
     # PATCH /tasks/:id (異常系)
     describe "PATCH /tasks/:id(異常系)" do
         it "存在しないIDなら404を返す" do
+            user = User.create!(email: "patchtest@example.com", password: "password")
+            sign_in user
             patch "/tasks/999999", params: {
                 task: { title: "更新後タスク" }
             }
@@ -127,10 +136,26 @@ RSpec.describe "Task API", type: :request do
         end
     end
 
+    # PATCH /tasks/:id (認証必須)
+    describe "PATCH /tasks/:id (認証必須)" do
+        it "未ログインの場合401を返す" do
+            user = User.create!(email: "patchtest@example.com", password: "password")
+            task = Task.create!(title: "未ログイン更新タスク", status: :not_started, user: user)
+            # ログインせずにPATCHリクエストを送信
+            patch "/tasks/#{task.id}", params: {
+                task: { title: "未ログインで更新" }
+            }
+            # HTTPステータスが401(Unauthorized)であることを確認
+            expect(response).to have_http_status(:unauthorized)
+            json = JSON.parse(response.body)
+            expect(json["errors"]).to include("You need to sign in or sign up before continuing.")
+        end
+    end
 
     describe "DELETE /tasks/:id" do
         it "タスクを削除できる" do
             user = User.create!(email: "test4@example.com", password: "password")
+            sign_in user
             task = Task.create!(title: "削除タスク", status: :not_started, user: user)
 
             delete "/tasks/#{task.id}"
@@ -143,6 +168,8 @@ RSpec.describe "Task API", type: :request do
     # DELETE /tasks/:id (異常系)
     describe "DELETE /tasks/:id (異常系)" do
         it "存在しないIDなら404を返す" do
+            user = User.create!(email: "test4@example.com", password: "password")
+            sign_in user
             delete "/tasks/999999"
 
             expect(response).to have_http_status(:not_found)
@@ -150,4 +177,20 @@ RSpec.describe "Task API", type: :request do
             expect(json["errors"]).to include("Task not found")
         end
     end
+
+    # DELETE /tasks/:id (認証必須)
+    describe "DELETE /tasks/:id (認証必須)" do
+        it "未ログインの場合401を返す" do
+            user = User.create!(email: "deletetest@example.com", password: "password")
+            task = Task.create!(title: "未ログイン削除タスク",status: :not_started, user: user)
+
+            # ログインせずにDELETEリクエストを送信
+            delete "/tasks/#{task.id}"
+
+            expect(response).to have_http_status(:unauthorized) # HTTPステータスが401(Unauthorized)であることを確認
+            json = JSON.parse(response.body)
+            expect(json["errors"]).to include("You need to sign in or sign up before continuing.")
+        end
+    end
+
 end


### PR DESCRIPTION
認証関連のリクエストスペックを追加しました。
- POST /tasks, PATCH /tasks/:id, DELETE /tasks/:id の正常系・異常系
- 未ログイン時401のテスト
