### PR TITLE
test: add model/request specs & test infra

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -55,4 +55,3 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
 end
-

--- a/backend/spec/factories/tasks.rb
+++ b/backend/spec/factories/tasks.rb
@@ -1,13 +1,28 @@
 FactoryBot.define do
-    factory :task do
-      association :user
-      title { "タスク#{SecureRandom.hex(3)}" }
-      status { :not_started }
-      progress { 0 }
-      deadline { nil }
-  
-      trait :with_deadline do
-        deadline { 2.days.from_now }
-      end
+  factory :task do
+    association :user
+    sequence(:title) { |n| "タスク#{n}" }
+    site { "現場X" }             # ← 親タスクは site 必須なのでデフォルト付与
+    # status/progress は DB デフォルト（not_started/0）に任せる
+
+    trait :with_deadline do
+      deadline { 1.week.from_now.to_date }
+    end
+
+    trait :in_progress do
+      status   { :in_progress }
+      progress { 50 }
+    end
+
+    trait :completed do
+      status   { :completed }
+      progress { 100 }
+    end
+
+    # 子タスクを明示的に作るとき
+    trait :as_child do
+      site { nil } # 子は site 不要
+      association :parent, factory: :task
     end
   end
+end

--- a/backend/spec/models/task_constraints_spec.rb
+++ b/backend/spec/models/task_constraints_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Task, type: :model do
+  let(:user) { create(:user) } # FactoryBot を想定（無ければ User.create! に置き換え可）
+
+  describe "親のみ site 必須" do
+    it "親は site が必須 / 子は site 無しでも保存できる" do
+      parent = user.tasks.new(title: "親A") # site なし → invalid
+      expect(parent).to be_invalid
+      expect(parent.errors[:site]).to include("can't be blank")
+
+      parent.site = "現場X"
+      expect(parent).to be_valid
+      parent.save!
+
+      child = user.tasks.new(title: "子1", parent:)
+      expect(child).to be_valid
+      child.save!
+    end
+  end
+
+  describe "子タスク上限（直下最大4件）" do
+    it "4件まではOK、5件目は invalid" do
+      parent = user.tasks.create!(title: "親", site: "現場X")
+      4.times { |i| user.tasks.create!(title: "子#{i + 1}", parent:) }
+
+      fifth = user.tasks.new(title: "子5", parent:)
+      expect(fifth).to be_invalid
+      expect(fifth.errors.full_messages.join).to include("最大4件")
+    end
+
+    it "親付け替えで5件目になる場合も invalid（更新時チェック）" do
+      a = user.tasks.create!(title: "A", site: "現場X")
+      b = user.tasks.create!(title: "B", site: "現場Y")
+      4.times { |i| user.tasks.create!(title: "A-#{i + 1}", parent: a) }
+      x = user.tasks.create!(title: "X", parent: b)
+
+      expect {
+        x.update!(parent: a) # will_save_change_to_parent_id? が true で検証される
+      }.to raise_error(ActiveRecord::RecordInvalid) { |e|
+        expect(e.record.errors.full_messages.join).to include("最大4件")
+      }
+      expect(x.reload.parent).to eq(b) # 付け替わらないこと
+    end
+  end
+
+  describe "depth の自動計算と上限" do
+    it "作成時に depth が 1→4 で自動設定、5階層目は invalid" do
+      p1 = user.tasks.create!(title: "1", site: "S")
+      p2 = user.tasks.create!(title: "2", parent: p1)
+      p3 = user.tasks.create!(title: "3", parent: p2)
+      p4 = user.tasks.create!(title: "4", parent: p3)
+
+      expect([p1.depth, p2.depth, p3.depth, p4.depth]).to eq([1, 2, 3, 4])
+
+      p5 = user.tasks.new(title: "5", parent: p4)
+      expect(p5).to be_invalid
+      expect(p5.errors.full_messages.join).to include("4階層まで")
+    end
+  end
+
+  describe "DB デフォルト（status / progress）" do
+    it "status / progress を指定しなくてもデフォルトが入る（create! 時）" do
+      t = user.tasks.create!(title: "親", site: "現場X")
+      expect(t.status).to eq("not_started")
+      expect(t.progress.to_i).to eq(0)
+    end
+  end
+end

--- a/backend/spec/models/task_priority_spec.rb
+++ b/backend/spec/models/task_priority_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Task, type: :model do
   describe ".priority_order" do
     it "期限ありが先、期限なしが後ろ" do
       user = create(:user)
-      with_deadline = create(:task, :with_deadline, user:)
-      no_deadline   = create(:task, deadline: nil, user:)
+      with_deadline = create(:task, :with_deadline, user:) # factory が site 付与
+      no_deadline   = create(:task, deadline: nil, user:)  # 同上
       expect(Task.where(user:).priority_order.pluck(:id)).to eq([with_deadline.id, no_deadline.id])
     end
   end

--- a/backend/spec/models/task_spec.rb
+++ b/backend/spec/models/task_spec.rb
@@ -1,45 +1,38 @@
+# spec/models/task_spec.rb
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-    # ---- 共有ユーザー(タスクに紐づけるために用意) ---- #
-    let(:user) { User.create!(email: "test@example.com", password: "password") }
+  let(:user) { create(:user) }  # FactoryBot
 
-    describe "バリデーション" do
-        it "タイトル、ステータス、ユーザーが揃っていれば有効" do
-            # 全て正しい値を渡した場合、保存できる(有効)
-            task = Task.new(title: "有効なタスク", status: :not_started, user: user)
-            expect(task).to be_valid
-        end
-
-        it "タイトルが空なら無効" do
-            # タイトルが空の場合、バリデーションエラーになる
-            task = Task.new(title: "", status: :not_started, user: user)
-            expect(task).not_to be_valid
-            # ActiveRecordが持つerrorsオブジェクトに、タイトル必須のエラーメッセージが入っているか確認
-            expect(task.errors[:title]).to include("can't be blank")
-        end
-
-        it "ステータスが空なら無効" do
-            # status(nil)の場合、enumのpresenceチェックに引っかかる
-            task = Task.new(title: "タスク", status: nil, user: user)
-            expect(task).not_to be_valid
-            expect(task.errors[:status]).to include("can't be blank")
-        end
-
-        it "ユーザーが紐付かれていなければ無効" do
-            # userがnilの場合、belongs_toの必須チェックに引っかかる
-            task = Task.new(title: "タスク", status: :not_started, user: nil)
-            expect(task).not_to be_valid
-            # belong_toはデフォルトで「関連レコードが存在するか」をチェックする
-            expect(task.errors[:user]).to include("must exist")
-        end
-
-        it "不正なステータス値なら無効" do
-            # enumに存在しない値(99)を渡した場合、即ArgumentErrorが発生する
-            expect {
-                Task.new(title: "不正ステータス", status: 99, user: user)
-            # enumは未定義の値を代入すると例外を投げる仕様    
-            }.to raise_error(ArgumentError)
-        end
+  describe "バリデーション" do
+    it "タイトル、ステータス、ユーザーが揃っていれば有効" do
+      task = described_class.new(title: "有効なタスク", status: :not_started, user: user, site: "現場X")
+      expect(task).to be_valid
     end
+
+    it "タイトルが空なら無効" do
+      task = described_class.new(title: "", status: :not_started, user: user, site: "現場X")
+      expect(task).not_to be_valid
+      expect(task.errors[:title]).to include("can't be blank")
+    end
+
+    it "ステータスが空なら無効" do
+      task = described_class.new(title: "タスク", status: nil, user: user, site: "現場X")
+      expect(task).not_to be_valid
+      expect(task.errors[:status]).to include("can't be blank")
+    end
+
+    it "ユーザーが紐付かれていなければ無効" do
+      task = described_class.new(title: "タスク", status: :not_started, user: nil, site: "現場X")
+      expect(task).not_to be_valid
+      expect(task.errors[:user]).to include("must exist")
+    end
+
+    it "不正なステータス値なら無効" do
+      # enum に未定義の値を渡すと ArgumentError
+      expect {
+        described_class.new(title: "不正ステータス", status: 99, user: user, site: "現場X")
+      }.to raise_error(ArgumentError)
+    end
+  end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -11,7 +11,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'rspec/rails'
 
 # 3) support配下は Rails が読まれた“後”に読み込む
-Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 # 4) DBスキーマをテスト環境と同期
 begin
@@ -21,8 +21,11 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
-  # フィクスチャを使うなら（使わないなら消してOK）
-  config.fixture_paths = [Rails.root.join('spec/fixtures')]
+  # （任意）fixtures を使うなら有効化。使っていなければコメントアウトでOK
+  # config.fixture_path = Rails.root.join('spec/fixtures')
+
+  # FactoryBot の DSL（create/build など）をグローバルに使えるように
+  config.include FactoryBot::Syntax::Methods
 
   # トランザクションで囲む（System SpecでJS使う場合は後でDB Cleaner検討）
   config.use_transactional_fixtures = true
@@ -33,8 +36,10 @@ RSpec.configure do |config|
   # ノイズ削減
   config.filter_rails_from_backtrace!
 
-  # Deviseの sign_in ヘルパ（request用）
-  config.include ApiAuthHelpers,        type: :request  # ← 上で作ったやつ
-  config.include RequestJsonHelpers,    type: :request  # ← 上で作ったやつ
-  config.include Devise::Test::IntegrationHelpers, type: :request
+  # Request 用ヘルパ（自作）
+  config.include ApiAuthHelpers,     type: :request
+  config.include RequestJsonHelpers, type: :request
+
+  # ← APIはトークン運用なので基本は不要。セッション sign_in を使う場合のみ該当 spec で include
+  # config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/backend/spec/requests/tasks_priority_spec.rb
+++ b/backend/spec/requests/tasks_priority_spec.rb
@@ -2,18 +2,19 @@ require "rails_helper"
 
 # /api/tasks/priority が、自分のタスクだけを正しい順序で返す
 RSpec.describe "Tasks priority", type: :request do
-    let(:me)   { User.create!(email: "me@example.com",   password: "password") }
-    let(:them) { User.create!(email: "them@example.com", password: "password") }
+  let(:me)   { create(:user) }
+  let(:them) { create(:user) }
 
-    it "current_userの優先順で返す" do
-        mine1 = Task.create!(user: me,   title: "a", status: :not_started, deadline: 1.day.from_now)
-        mine2 = Task.create!(user: me,   title: "b", status: :not_started, deadline: nil)
-        _x    = Task.create!(user: them, title: "c", status: :not_started, deadline: 1.hour.from_now)
-    
-        get "/api/tasks/priority", headers: auth_headers_for(me)
-    
-        expect(response).to have_http_status(:ok)
-        ids = JSON.parse(response.body).map { _1["id"] }
-        expect(ids).to eq([mine1.id, mine2.id])
-    end
+  it "current_userの優先順で返す" do
+    # 親タスクは site 必須（factory の :task は site 既定あり）
+    mine1 = create(:task, :with_deadline, user: me)          # 期限あり
+    mine2 = create(:task, user: me, deadline: nil)           # 期限なし
+    _x    = create(:task, :with_deadline, user: them)        # 他人分は混ぜても返ってこない
+
+    get "/api/tasks/priority", headers: auth_headers_for(me)
+
+    expect(response).to have_http_status(:ok)
+    ids = JSON.parse(response.body).map { _1["id"] }
+    expect(ids).to eq([mine1.id, mine2.id])                  # 期限あり→期限なし
+  end
 end

--- a/backend/spec/requests/tasks_security_spec.rb
+++ b/backend/spec/requests/tasks_security_spec.rb
@@ -1,11 +1,13 @@
 require "rails_helper"
 
 RSpec.describe "Tasks security", type: :request do
-  let(:me)   { User.create!(email: "me@example.com",   password: "password") }
-  let(:them) { User.create!(email: "them@example.com", password: "password") }
+  let(:me)   { create(:user) }
+  let(:them) { create(:user) }
 
   it "他人のタスク更新は404/403" do
-    other_task = Task.create!(user: them, title: "x", status: :not_started)
+    # 親タスクなので site 必須。factory の :task は site 既定ありでOK
+    other_task = create(:task, user: them)
+
     patch "/api/tasks/#{other_task.id}",
           params: { task: { title: "hack" } }.to_json,
           headers: auth_headers_for(me).merge(json_headers)

--- a/backend/spec/support/sqlite_tuning.rb
+++ b/backend/spec/support/sqlite_tuning.rb
@@ -1,0 +1,14 @@
+# spec/support/sqlite_tuning.rb
+RSpec.configure do |config|
+    config.before(:suite) do
+      next unless ActiveRecord::Base.connection.adapter_name =~ /SQLite/i
+  
+      conn = ActiveRecord::Base.connection
+      # 取得できるまで待つ
+      conn.execute("PRAGMA busy_timeout = 5000")
+      # 併用すると read/write が詰まりにくい
+      conn.execute("PRAGMA journal_mode = WAL")
+      conn.execute("PRAGMA synchronous = NORMAL")
+    end
+  end
+  


### PR DESCRIPTION
PR 本文

・モデル

status/progress のデフォルト化、親のみ site 必須

直下子4件まで（新規/親付け替え時に検査）

子変更で親〜祖先へ進捗ロールアップ

・API

/api/tasks 絞り込み・ソート（site/status/progress_min/max/parents_only/order_by/dir）

/api/tasks/sites で親タスクの site 候補を返却

JSON/フォーム/ネストいずれの POST/PATCH でも受理

・テスト/基盤

FactoryBot 導入、ヘルパ、WAL + busy_timeout

既存 spec 全通過