### PR TITLE
feat(auth): ユーザー名をヘッダーに表示

### DIFF
--- a/backend/app/controllers/api/users_controller.rb
+++ b/backend/app/controllers/api/users_controller.rb
@@ -1,0 +1,11 @@
+module Api
+    class UsersController < Api::BaseController
+      # devise_token_auth（namespace: api）なのでこれでOK
+      before_action :authenticate_api_user!
+  
+      def me
+        render json: current_api_user.slice(:id, :email, :name)
+      end
+    end
+  end
+  

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   namespace :api do
     mount_devise_token_auth_for 'User', at: 'auth'
 
+    get "me", to: "users#me"
+
     resources :tasks do
       collection do
         get :priority


### PR DESCRIPTION
## 概要
ユーザー情報 API 連携を追加し、ヘッダーにユーザー名を表示できるようにした。

## 変更内容
- backend
  - `/api/me` エンドポイントを追加（ログイン中ユーザーの `id/email/name` を返す）
  - `UsersController#me` を実装
- frontend
  - `AuthContext` に `name` を追加し、`/api/me` から取得・保持するよう修正
  - Header コンポーネントで `name ?? uid` を表示するよう変更

## 動作確認
1. `bin/rails s` で API サーバー起動
2. `pnpm dev` でフロントエンド起動
3. `dev@example.com / password` でログイン
4. ヘッダー右上に `dev@example.com さん` と表示されることを確認

## 影響範囲 / リスク
- 認証周りの処理に `name` を追加したため、AuthContext を利用する箇所が影響を受ける可能性あり
- `/api/me` のレスポンス仕様変更が将来的に入る場合は修正が必要

## ロールバック方法
- frontend 側で `AuthContext` から `name` を削除し、Header の表示を `uid` のみに戻す
- backend 側の `/api/me` ルートと `UsersController#me` を削除

## 補足
- 今後、プロフィール編集やダークモード切替の実装時にユーザー情報を利用可能
