### PR TITLE
feat(drawer): 画像プレビュー(1枚・存在時のみ)を追加し原寸リンクを付与

### DIFF
--- a/backend/app/controllers/api/tasks_controller.rb
+++ b/backend/app/controllers/api/tasks_controller.rb
@@ -49,7 +49,6 @@ module Api
       render json: tasks.as_json(only: SELECT_FIELDS)
     end
 
-    # ==== ここを差し替え ====
     def show
       t = @task
 

--- a/frontend/src/features/drawer/ImagePreview.tsx
+++ b/frontend/src/features/drawer/ImagePreview.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from "react";
+
+type Props = {
+  url: string;
+  title: string;
+};
+
+export default function ImagePreview({ url, title }: Props) {
+  const [loaded, setLoaded] = useState(false);
+  const [err, setErr] = useState<Error | null>(null);
+
+  // エラー時は簡易プレースホルダにフォールバック
+  if (err) {
+    return (
+      <figure className="rounded-md border bg-gray-50">
+        <div className="flex h-44 items-center justify-center text-xs text-gray-500">
+          画像を読み込めませんでした
+        </div>
+        <figcaption className="border-t px-3 py-2 text-[11px] text-gray-600">
+          画像プレビュー（クリックで原寸表示）
+        </figcaption>
+      </figure>
+    );
+  }
+
+  return (
+    <figure className="rounded-md border bg-white">
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block"
+        aria-label="画像を新しいタブで開く"
+      >
+        {/* 画像本体 */}
+        <img
+          src={url}
+          alt={`${title} の画像`}
+          className={`block h-44 w-full object-cover ${loaded ? "" : "hidden"}`}
+          onLoad={() => setLoaded(true)}
+          onError={() => setErr(new Error("image load failed"))}
+          loading="lazy"
+          decoding="async"
+          referrerPolicy="no-referrer"
+        />
+        {/* ローディング中のプレースホルダ */}
+        {!loaded && (
+          <div className="h-44 w-full animate-pulse bg-gray-200" aria-hidden />
+        )}
+      </a>
+      <figcaption className="border-t px-3 py-2 text-[11px] text-gray-600">
+        画像プレビュー（クリックで原寸表示）
+      </figcaption>
+    </figure>
+  );
+}

--- a/frontend/src/features/drawer/TaskDrawer.tsx
+++ b/frontend/src/features/drawer/TaskDrawer.tsx
@@ -1,3 +1,4 @@
+// src/features/drawer/TaskDrawer.tsx
 import React, { useEffect, useMemo, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useTaskDrawer } from "./useTaskDrawer";
@@ -9,6 +10,7 @@ import StatusPill from "../../components/StatusPill";
 import ProgressBar from "../../components/ProgressBar";
 import { toYmd } from "../../utils/date";
 import ChildPreviewList from "./ChildPreviewList";
+import ImagePreview from "./ImagePreview";
 
 const RootPortal: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const el = useMemo(() => document.createElement("div"), []);
@@ -59,9 +61,10 @@ export default function TaskDrawer() {
   const descId = "task-drawer-desc";
 
   // --- セーフティ（undefined/null を吸収） ---
-  const prog = Math.max(0, Math.min(100, Math.round((data?.progress_percent ?? 0))));
+  const prog = Math.max(0, Math.min(100, Math.round(data?.progress_percent ?? 0)));
   const preview = data?.children_preview ?? [];
   const grandkids = typeof data?.grandchildren_count === "number" ? data!.grandchildren_count : 0;
+  const imageUrl = data?.image_url ?? null;
 
   return (
     <RootPortal>
@@ -81,7 +84,7 @@ export default function TaskDrawer() {
       >
         {/* ヘッダー（accessible name はタスク名） */}
         <div className="flex items-center justify-between border-b px-4 py-3">
-          <h2 id={titleId} className="text-base font-semibold truncate">
+          <h2 id={titleId} className="truncate text-base font-semibold">
             {data?.title ?? "タスク詳細"}
           </h2>
           <button
@@ -157,7 +160,14 @@ export default function TaskDrawer() {
               {/* 直下の子プレビュー（最大4件）＆孫件数 */}
               <ChildPreviewList items={preview} grandchildrenCount={grandkids} />
 
-              {/* 4行目：監査情報 */}
+              {/* 画像（存在時のみ） */}
+              {imageUrl && (
+                <div className="mt-4">
+                  <ImagePreview url={imageUrl} title={data.title} />
+                </div>
+              )}
+
+              {/* 監査情報 */}
               <div className="mt-4 grid grid-cols-2 gap-3 text-[12px] text-gray-600">
                 <div>
                   作成者:{" "}


### PR DESCRIPTION
# 概要
詳細ドロワーに画像プレビューを追加。image_url がある場合のみ表示し、クリックで原寸を新規タブで開く。

# 変更
- 新規: ImagePreview コンポーネント
- TaskDrawer に画像セクションを挿入（子プレビューの下／監査情報の上）
- スケルトン表示、読み込み失敗時のフォールバック

# 動作確認
- image_url あり → サムネ表示＆原寸リンク
- image_url なし → セクション非表示
- 既存A11y/フォーカストラップ/スクロールロックは維持
