### PR TITLE
infra: ECS Fargate(ARM64)+ALB で Rails API をデプロイ、ECR/タスク定義/ロール/SG/Logs…

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -67,3 +67,9 @@ export default tseslint.config([
   },
 ])
 ```
+docs/deploy-notes.md
+├─ ECR push 手順
+├─ IAM Role 作成
+├─ Task 定義
+├─ ALB/TargetGroup 設定
+└─ DoD (/up healthy)


### PR DESCRIPTION
… を設定して /up healthy を確認## 目的
- Rails API を AWS ECS Fargate(ARM64) + ALB でパブリック公開し、/up のヘルスチェックが 200 で通ることを確認する。

## 変更概要
- ECR リポジトリ作成＆イメージ push（:latest）
- ECS クラスター／サービス作成（Fargate, awsvpc, Public IP）
- タスク定義（ARM64, CPU 512 / MEM 1024, containerPort 3000）
- 実行ロール・タスクロール作成（ecs-tasks.amazonaws.com の信頼ポリシー）
- セキュリティグループ作成
  - ALB: 0.0.0.0/0 :80 IN
  - ECS: ALB SG から :3000 IN, 0.0.0.0/0 OUT
  - RDS: ECS SG から :3306 IN（将来のDB接続用）
- ALB / Target Group 作成（target-type=ip, HC: GET /up, 200）
- CloudWatch Logs `/ecs/genba-task` 出力設定
- `SECRET_KEY_BASE` をタスク定義の環境変数に設定
- デプロイ後、ターゲットが healthy になったことを確認

## 動作確認
- `curl http://<ALB_DNS>/up` → **200 OK** を確認  
 {"status":"ok","app":"genba-task-api","sha":"unknown","rails_env":"production","time":"...","db":true}

## 変更の影響範囲
- インフラ（ECS/ALB/IAM/SG/CloudWatch Logs）
- アプリコードへの変更なし（デプロイ用の設定のみ）

## セキュリティ
- タスク実行ロール: `AmazonECSTaskExecutionRolePolicy` を付与
- タスクロール: 現状は最小限（アプリが外部AWSにアクセスする場合は別途付与）
- `SECRET_KEY_BASE` はタスク定義の環境変数に設定（次ステップで Secrets Manager へ移行予定）

## DoD（達成条件）
- [x] ECR へコンテナイメージを push 済み
- [x] ECS サービスが起動し、ターゲットが `healthy`
- [x] `http://<ALB_DNS>/up` が `200` を返す
- [x] CloudWatch Logs に Rails 起動ログが出力される

## 今後のタスク（別PR）
- [ ] RDS 本番用のパラメータ/Secret 管理（Secrets Manager 統合）
- [ ] HTTPS 化（ACM 証明書発行 → ALB リスナー :443）
- [ ] CI/CD（GitHub Actions → ECR push → ECS サービス更新）
- [ ] オートスケーリングとヘルスチェック調整（HC grace/threshold）
- [ ] 監視/通知（Target Unhealthy, Task Stopped, 5xx などを SNS/Slack）
- [ ] コストタグ付与・クリーンアップスクリプト整備