### PR TITLE
docs(infra): RDS(MySQL)切替手順を追記

### DIFF
--- a/backend/docs/infra/2025-09-16-rds-mysql-cutover.md
+++ b/backend/docs/infra/2025-09-16-rds-mysql-cutover.md
@@ -1,0 +1,16 @@
+# RDS(MySQL) 切替メモ
+- エンドポイント: genba-task-db.cr4k6e08yxdh.ap-northeast-1.rds.amazonaws.com
+- DB名: genba_task_production
+- ユーザー: app_user
+
+## SSM
+- /genba_task/prod/DB_HOST
+- /genba_task/prod/DB_NAME
+- /genba_task/prod/DB_USER
+- /genba_task/prod/DB_PASSWORD (SecureString)
+
+## デプロイ手順
+1) ECS タスク定義 Secrets に上記を追加→新リビジョン
+2) Run Task: `bash -lc "bundle exec rails db:migrate"`
+3) サービス更新 → `http://<ALB-DNS>/up` = 200
+4) RDS SG: genba-ecs-sg のみ許可（MyIPは削除）


### PR DESCRIPTION
## 目的
- 本番DBをRDS(MySQL)へ切替し、ECSから安全に接続できるようにする

## 変更点
- config/database.yml: production を ENV 参照（DB_HOST/DB_NAME/DB_USER/DB_PASSWORD, ssl_mode: required）
- docs/infra: RDS接続手順・SSMキー一覧を追記

## デプロイ手順
1. ECS タスク定義に Secrets（/genba_task/prod/DB_*）を追加→新リビジョン作成
2. Run Task（SG=genba-ecs-sg）で `bundle exec rails db:migrate`
3. サービスを最新リビジョンに更新
4. `curl http://<ALB-DNS>/up` が 200

## 確認観点
- ALB ヘルスチェック Healthy
- アプリログで DB 接続成功
- RDS SG は genba-ecs-sg のみ許可（ローカルIP開放は削除）
