### PR TITLE
feat(ui): 親タスクのバッジ位置を本番と揃え、子タスク表示を最大4件に制限（READMEデモ向け）

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/components/ConfirmPopover 2.tsx
+++ b/frontend/src/components/ConfirmPopover 2.tsx
@@ -1,0 +1,60 @@
+// frontend/src/components/ConfirmPopover.tsx
+import { useEffect, useRef } from "react";
+
+type Props = {
+  text?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function ConfirmPopover({ text = "このタスクを削除しますか？", onConfirm, onCancel }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  // 外側クリックで閉じる
+  useEffect(() => {
+    const onDoc = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) onCancel();
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [onCancel]);
+
+  // 初期フォーカス
+  useEffect(() => { cancelRef.current?.focus(); }, []);
+
+  // Escキーで閉じる
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onCancel(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-modal="true"
+      className="absolute z-50 mt-2 w-72 rounded-lg border border-gray-200 bg-white p-3 shadow-lg"
+    >
+      <p className="text-sm text-gray-800">{text}</p>
+      <div className="mt-3 flex justify-end gap-2">
+        <button
+          ref={cancelRef}
+          type="button"
+          className="px-3 py-1.5 rounded border border-gray-300 text-sm hover:bg-gray-50"
+          onClick={onCancel}
+        >
+          キャンセル
+        </button>
+        <button
+          type="button"
+          className="px-3 py-1.5 rounded bg-red-600 text-white text-sm hover:bg-red-700"
+          onClick={onConfirm}
+        >
+          削除
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/brandIso 2.ts
+++ b/frontend/src/lib/brandIso 2.ts
@@ -1,0 +1,6 @@
+// src/lib/brandIso.ts
+import type { IsoDateString } from "../types";
+/** undefined を必ず null に落としてブランド化 */
+export function brandIso(input?: string | null): IsoDateString | null {
+  return (input == null ? null : (input as IsoDateString));
+}

--- a/frontend/src/lib/demoStore 2.ts
+++ b/frontend/src/lib/demoStore 2.ts
@@ -1,0 +1,70 @@
+// src/lib/demoStore.ts
+import type { Task } from "../type";
+
+const KEY = "demo:tasks";
+const IDK = "demo:nextId";
+
+function read(): Task[] {
+  try { return JSON.parse(localStorage.getItem(KEY) || "[]"); } catch { return []; }
+}
+function write(x: Task[]) { localStorage.setItem(KEY, JSON.stringify(x)); }
+function nextId(): number {
+  const n = Number(localStorage.getItem(IDK) || "1");
+  localStorage.setItem(IDK, String(n + 1));
+  return n;
+}
+
+// 初回シード（空なら簡単なタスクを投入）
+(function seed() {
+  const cur = read();
+  if (cur.length === 0) {
+    const now = new Date();
+    const d = (days: number) => new Date(now.getTime() + days * 864e5).toISOString();
+    const items: Task[] = [
+      { id: nextId(), title: "現場A 見積もり", status: "in_progress", progress: 40, deadline: d(3), site: "現場A", parent_id: null },
+      { id: nextId(), title: "資材発注",       status: "not_started", progress: 0,  deadline: d(5), site: "現場A", parent_id: null },
+      { id: nextId(), title: "現場B 朝礼準備", status: "completed",   progress: 100,deadline: d(0), site: "現場B", parent_id: null },
+    ];
+    write(items);
+  }
+})();
+
+export const demoStore = {
+  list(): Task[] { return read(); },
+  create(payload: Partial<Task>): Task {
+    const all = read();
+    const t: Task = {
+      id: nextId(),
+      title: payload.title ?? "無題のタスク",
+      status: payload.status ?? "not_started",
+      progress: payload.progress ?? 0,
+      deadline: payload.deadline ?? null,
+      site: payload.site ?? null,
+      parent_id: payload.parent_id ?? null,
+    };
+    write([t, ...all]);
+    return t;
+  },
+  get(id: number): Task | undefined { return read().find(t => t.id === id); },
+  update(id: number, patch: Partial<Task>): Task | undefined {
+    const all = read();
+    const i = all.findIndex(t => t.id === id);
+    if (i < 0) return;
+    all[i] = { ...all[i], ...patch };
+    write(all);
+    return all[i];
+  },
+  remove(id: number): void {
+    write(read().filter(t => t.id !== id));
+  },
+  sites(): string[] {
+    return Array.from(new Set(read().map(t => t.site).filter(Boolean))) as string[];
+  },
+  priority(): Task[] {
+    // ざっくり「期限が近い or 進捗<50%」を上位に
+    const list = read();
+    const score = (t: Task) => (t.deadline ? Date.parse(t.deadline) : 9e15) + (t.progress ?? 0) * 1e10;
+    return [...list].sort((a, b) => score(a) - score(b)).slice(0, 5);
+  },
+  reset(): void { write([]); localStorage.removeItem(IDK); },
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    "./index.html",
+    "./src/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: { extend: {} },
+  plugins: [],
+};


### PR DESCRIPTION
## 目的

* ローカル環境でタイトル横に表示されていたバッジ（「上位タスク」「自動 x/y OK」）を**本番と同じメタ情報行**へ移動。
* README 用デモで見やすくするため、**子タスクは最大 4 件のみ表示**し、残件は「他 n 件」で明示。
* main を取り込み、**ローカルと本番の UI 差異**を解消。

## 変更点

* `frontend/src/features/tasks/inline/InlineTaskRow.tsx`

  * バッジのDOMをメタ情報行へ移動。
  * 子タスク表示を `shownChildren = orderedChildren.slice(0, 4)` に制限し、`remainingChildren` を補足表示。
  * レイアウト微調整（余白/フォントサイズ/行間は本番寄せ）。

## 動作確認

* [x] 親タスク行のタイトル横にバッジが出ない
* [x] メタ情報行に「上位タスク」バッジ表示
* [x] 子タスクが 5 件以上存在しても **4 件まで**表示され「他 n 件」表示になる
* [x] 画像パネルや DnD、編集/削除動作に影響なし
* [x] フィルタ・並び替えで回帰なし
* [x] 本番とローカルで UI の見た目が一致

## 影響範囲

* 親タスク行の表示コンポーネントのみ。API/I/F 変更なし。E2E 影響軽微。

## リスクとロールバック

* 低。視覚のみの変更。問題があればこのファイルの差分をリバート。

## 関連

* #98（サイドバー/タイトル調整）取り込み済み

