### PR TITLE
ci(aws): OIDC認証確認用ワークフローを追加

### DIFF
--- a/.github/workflows/aws-oidc-check.yml
+++ b/.github/workflows/aws-oidc-check.yml
@@ -1,0 +1,20 @@
+name: AWS OIDC Check
+on:
+  workflow_dispatch: # 手動実行
+
+jobs:
+  whoami:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+      - name: Show caller identity
+        run: aws sts get-caller-identity


### PR DESCRIPTION
### 概要
AWS OIDC（GitHub Actions → IAMロール）の接続確認用ワークフローを追加。

### 変更内容
- `.github/workflows/aws-oidc-check.yml` を新規作成
  - `workflow_dispatch`（手動実行）
  - `aws-actions/configure-aws-credentials@v4` を利用してSTS認証確認
  - `aws sts get-caller-identity` によりAWSアカウントIDを出力

### 動作確認
1. GitHub Actions → 「AWS OIDC Check」 → 「Run workflow」を実行  
2. ログに以下のように表示されることを確認  
   ```
   "Account": "711652947752"
   ```

### 影響範囲 / リスク
- 認証テスト専用。デプロイや本番環境への影響なし。

### ロールバック方法
- `.github/workflows/aws-oidc-check.yml` を削除すれば元通り。
