### PR TITLE
ci(front): S3+CloudFront 自動デプロイ追加（OIDC）

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -1,0 +1,65 @@
+name: Deploy Frontend (S3 + CloudFront)
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/deploy-front.yml"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: 'frontend/.nvmrc'
+          cache: 'pnpm'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install deps
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: frontend
+        env:
+          VITE_API_BASE_URL: ${{ vars.VITE_API_BASE_URL }}
+        run: pnpm build
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Sync assets (immutable)
+        working-directory: frontend
+        run: |
+          aws s3 sync ./dist s3://${{ vars.S3_BUCKET }}/ \
+            --delete --exclude "index.html" \
+            --cache-control "public,max-age=31536000,immutable"
+
+      - name: Upload index.html (no-cache)
+        working-directory: frontend
+        run: |
+          aws s3 cp ./dist/index.html s3://${{ vars.S3_BUCKET }}/index.html \
+            --cache-control "no-cache" \
+            --content-type "text/html" \
+            --metadata-directive REPLACE
+
+      - name: Invalidate CloudFront
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/index.html" "/"


### PR DESCRIPTION
## 概要
GitHub Actions によるフロントエンドの自動デプロイを追加しました。  
main ブランチへの push 時に、Vite ビルド後 S3 + CloudFront に自動反映されます。

## 変更内容
- `.github/workflows/deploy-front.yml` を新規追加
- AWS OIDC ロール認証を使用（手動キー不要）
- S3 へビルド成果物を同期（immutable assets / no-cache index.html）
- CloudFront のキャッシュ無効化を自動実行

## 動作確認
1. `AWS OIDC Check` ワークフローで `Account: 711652947752` が確認できること
2. `Deploy Frontend (S3 + CloudFront)` ワークフローが緑で完了
3. S3 バケットに `index.html` および `assets/` がアップロードされること
4. CloudFront の invalidation が作成され、変更が即時反映されること

## 影響範囲 / リスク
- デプロイジョブが main push 時に自動実行される
- AWS IAM ロール権限が不足している場合、sync/invalidation に失敗する可能性あり

## ロールバック方法
- `.github/workflows/deploy-front.yml` を削除 or `on.push` 条件を無効化することで停止可能

## 補足
- Node バージョンは `frontend/.nvmrc` の内容に依存  
- 環境変数は以下を GitHub Environments に設定済み  
  - `AWS_ROLE_ARN`
  - `AWS_REGION`
  - `S3_BUCKET`
  - `CLOUDFRONT_DISTRIBUTION_ID`
  - `VITE_API_BASE_URL`
