### PR TITLE
ci(front): S3+CloudFront 自動デプロイWorkflowを追加（OIDC）

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -14,19 +14,20 @@ jobs:
     permissions:
       id-token: write
       contents: read
-
     steps:
       - uses: actions/checkout@v4
 
-      # Node.js セットアップ
+      # Node を先に入れる（キャッシュ指定は外す）
       - uses: actions/setup-node@v4
         with:
           node-version-file: 'frontend/.nvmrc'
-          cache: 'pnpm'
 
-      # ✅ ここで pnpm をセットアップ
-      - name: Setup pnpm
-        run: npm install -g pnpm
+      # ここで pnpm をセットアップ（どちらか一方でOK）
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      # or:
+      # - run: npm install -g pnpm
 
       - name: Install deps
         working-directory: frontend


### PR DESCRIPTION
## 概要
main ブランチへの push でフロントを自動デプロイできるようにしました。
Vite ビルド → S3 へ配置（assetsはimmutable、index.htmlはno-cache）→ CloudFront 無効化 まで実行します。

## 変更点
- `.github/workflows/deploy-front.yml` を追加
  - Node は `.nvmrc` で固定
  - `pnpm` をセットアップしてビルド
  - OIDC で AWS にログイン（`aws-actions/configure-aws-credentials@v4`）
  - `aws s3 sync` / `aws cloudfront create-invalidation` を実行

## 必要な環境変数（GitHub Environments: production）
- Secret: `AWS_ROLE_ARN`
- Vars: `AWS_REGION`, `S3_BUCKET`, `CLOUDFRONT_DISTRIBUTION_ID`, `VITE_API_BASE_URL`

## 動作確認
1. このPRをマージして `main` に反映
2. Actions の `Deploy Frontend (S3 + CloudFront)` が成功すること
3. S3 に `index.html` と `assets/` がアップロードされること
4. CloudFront の Invalidation が作成され、サイトに変更が反映されること

## 影響範囲
- `main` への push で自動デプロイが走ります

## ロールバック
- `.github/workflows/deploy-front.yml` を削除 or `on.push` 条件を外せば停止可能
