### PR TITLE
feat(api-demo): ゲスト用ミニAPIを追加（API Gateway + Lambda / SAM）

### DIFF
--- a/.github/workflows/deploy-demo-api.yml
+++ b/.github/workflows/deploy-demo-api.yml
@@ -1,0 +1,64 @@
+name: Deploy Demo API (APIGW + Lambda)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    paths:
+      - "backend/demo-api/**"
+      - ".github/workflows/deploy-demo-api.yml"
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      AWS_REGION: ap-northeast-1
+    steps:
+      - uses: actions/checkout@v4
+
+      # OIDCでAWS認証
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}   # 既存のロールを流用
+          aws-region: ${{ env.AWS_REGION }}
+
+      # SAM CLI を最小インストール
+      - name: Install SAM CLI
+        run: |
+          pipx install aws-sam-cli
+          sam --version
+
+      # ビルド & デプロイ（S3バケットは --resolve-s3 で自動）
+      - name: SAM build
+        working-directory: backend/demo-api
+        run: sam build --use-container=false
+
+      - name: SAM deploy
+        id: deploy
+        working-directory: backend/demo-api
+        run: |
+          sam deploy \
+            --stack-name genba-demo-api \
+            --resolve-s3 \
+            --capabilities CAPABILITY_IAM \
+            --no-fail-on-empty-changeset \
+            --parameter-overrides AllowedOrigin=https://app.genba-tasks.com StageName=prod \
+            --region ${{ env.AWS_REGION }} \
+            --no-confirm-changeset
+
+      # 出力（API URL をアクションのサマリーに表示）
+      - name: Show endpoint
+        working-directory: backend/demo-api
+        run: |
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name genba-demo-api \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiInvokeUrl'].OutputValue" \
+            --output text)
+          echo "API URL: ${API_URL}"
+          echo "### Demo API Endpoint" >> $GITHUB_STEP_SUMMARY
+          echo "${API_URL}" >> $GITHUB_STEP_SUMMARY

--- a/backend/demo-api/src/handler.mjs
+++ b/backend/demo-api/src/handler.mjs
@@ -1,0 +1,39 @@
+// Node.js 20 (ESM)
+const ORIGIN = process.env.ALLOWED_ORIGIN || "https://app.genba-tasks.com";
+
+// CORSヘッダ
+function corsHeaders() {
+  return {
+    "Access-Control-Allow-Origin": ORIGIN,
+    "Access-Control-Allow-Headers": "Content-Type,Authorization",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Vary": "Origin",
+  };
+}
+
+export async function health() {
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    body: JSON.stringify({ ok: true, ts: Date.now() }),
+  };
+}
+
+// ※必要最小限の“ゲスト開始”API（POST /guest/login）
+export async function guestLogin(event) {
+  // ここではダミーのトークンを返すだけ（書き込み不要・コスト0運用）
+  const body = {
+    token: "guest-demo-token",
+    user: { id: "guest", name: "Guest User" },
+  };
+  return {
+    statusCode: 200,
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
+    body: JSON.stringify(body),
+  };
+}
+
+// 事前フライト（OPTIONS）
+export async function preflight() {
+  return { statusCode: 204, headers: corsHeaders(), body: "" };
+}

--- a/backend/demo-api/template.yaml
+++ b/backend/demo-api/template.yaml
@@ -1,0 +1,76 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: "Genba Tasks - Demo API (guest only)"
+
+Parameters:
+  AllowedOrigin:
+    Type: String
+    Default: https://app.genba-tasks.com
+  StageName:
+    Type: String
+    Default: prod
+
+Globals:
+  Function:
+    Runtime: nodejs20.x
+    MemorySize: 128
+    Timeout: 5
+    Architectures: [ arm64 ]
+    Tracing: Active
+    Handler: src/handler.health
+    Environment:
+      Variables:
+        ALLOWED_ORIGIN: !Ref AllowedOrigin
+
+Resources:
+  # HTTP API（安価・高速）
+  HttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: !Ref StageName
+      CorsConfiguration:
+        AllowOrigins: [ !Ref AllowedOrigin ]
+        AllowMethods: [ GET, POST, OPTIONS ]
+        AllowHeaders: [ Content-Type, Authorization ]
+        MaxAge: 86400
+
+  HealthFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handler.health
+      Events:
+        GetHealth:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /health
+            Method: GET
+        OptHealth:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /health
+            Method: OPTIONS
+
+  GuestLoginFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handler.guestLogin
+      Events:
+        PostGuestLogin:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /guest/login
+            Method: POST
+        OptGuestLogin:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref HttpApi
+            Path: /guest/login
+            Method: OPTIONS
+
+Outputs:
+  ApiInvokeUrl:
+    Description: "Invoke URL (base)"
+    Value: !Sub "https://${HttpApi}.execute-api.${AWS::Region}.amazonaws.com/${StageName}"


### PR DESCRIPTION
■ 概要
ゲスト体験をECS/RDSに依存させないため、APIGW + Lambda の最小API（/health, /guest/login）を追加。

■ 変更内容
- backend/demo-api/ 配下を新規追加（SAM, Node.js 20, arm64, Timeout 5s）
- エンドポイント:
  - GET /health（稼働確認）
  - POST /guest/login（ダミートークン返却）
- CORS: ALLOWED_ORIGIN（デフォルト https://app.genba-tasks.com）
- CloudFormation Outputs: ApiInvokeUrl

■ 動作確認
- `sam build && sam deploy` でスタック作成
- `curl "$API/prod/health"` が 200 / JSON を返す
- `curl -X POST "$API/prod/guest/login"` が 200 / token を返す
- CORS: OPTIONS が 204 を返すこと（ブラウザで確認）

■ 影響範囲/リスク
- 既存のALB/ECS/RDS/S3には影響なし（新規横付け）
- 将来の最小権限化は別PRで実施予定

■ ロールバック
- `sam delete --stack-name genba-demo-api`

■ 補足
- 後続PRでCI/CDとフロントの切替を行う
