### PR TITLE
feat(frontend): ゲストログイン対応（/guest/login）＋ apiClient の /api 除去

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -13,8 +13,8 @@ import { demoStore } from "./demoStore";
  * 未設定なら相対 "/api"
  */
 const base = import.meta.env.VITE_API_BASE_URL
-  ? `${import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "")}/api`
-  : "/api";
+  ? import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "")   // ← /api を足さない
+  : "/";
 
 const api = axios.create({
   baseURL: base,
@@ -29,7 +29,8 @@ const DEMO = import.meta.env.VITE_DEMO_MODE === "true";
 const AUTH_WHITELIST = [
   /^\/auth\//,       // /auth/sign_in, /auth/sign_out など
   /^\/omniauth\//,
-  /^\/healthz?$/,    // /health or /healthz
+  /^\/healthz?$/,
+  /^\/guest\/login$/, 
 ];
 
 /** ===== Header helpers ===== */

--- a/frontend/src/providers/useAuth.ts
+++ b/frontend/src/providers/useAuth.ts
@@ -1,5 +1,5 @@
 import { useContext } from "react";
-import { AuthContext } from "./AuthContext"; // ← ここを AuthContext に
+import { AuthContext } from "./AuthContext";
 
 export default function useAuth() {
   const ctx = useContext(AuthContext);


### PR DESCRIPTION
## 目的
ポートフォリオの「ゲストで試す」を、常時稼働コストを抑えた APIGW+Lambda 構成に接続。
/guest/login を叩いてフロント側でトークン保存→/tasks 遷移までを自動化。

## 変更点
- AuthContext:
  - `guestSignIn()` を追加。`POST {VITE_API_BASE_URL}/guest/login` を実行し、ヘッダ or ボディのトークンを保存。
  - 既存のトークン保存ロジック（ヘッダ優先／startedAt 競合回避）を流用。
- Login:
  - 「ゲストユーザーで試す」→ `guestSignIn()` を呼ぶよう変更。成功後 `/tasks` に遷移。
- apiClient:
  - baseURL からの `/api` 付与を廃止（APIGW の `/prod` を直接指定）。
  - `AUTH_WHITELIST` に `/guest/login` を追加。
  - 既存の DEMO モードはそのまま（`VITE_DEMO_MODE` で切替）。

## 環境変数
- `VITE_API_BASE_URL` 例:
  - 本番: `https://xxxx.execute-api.ap-northeast-1.amazonaws.com/prod`
  - 独自ドメイン運用時: `https://api.genba-tasks.com/prod`（ALB→APIGW 構成に合わせて調整）

## 動作確認（手順）
1. ブラウザで `GET {VITE_API_BASE_URL}/health` が 200 になることを確認。
2. アプリのログイン画面で「ゲストユーザーで試す」をクリック。
3. DevTools Network:
   - `POST {VITE_API_BASE_URL}/guest/login` が 200
   - レスポンスヘッダ（またはボディ）から `access-token/client/uid` が localStorage に保存
4. `/tasks` に遷移し、タスク一覧がデモ/ゲストとして利用可能。

## リスク/影響
- **BREAKING**: これまで `/api` を足していた前提の API エンドポイントは使えません。
  - 既存の Rails/Express の `/api/*` 直下バックエンドに向ける場合は `VITE_API_BASE_URL` を適切に変更してください。

## 参考
- フロント自動デプロイ: S3 + CloudFront（Actions 経由）
- API 自動デプロイ: SAM（APIGW + Lambda）
