### PR TITLE
feat(demo-api): /guest/login に CORS・ExposeHeaders・トークン系ヘッダを追加

### DIFF
--- a/backend/demo-api/template.yaml
+++ b/backend/demo-api/template.yaml
@@ -17,21 +17,32 @@ Globals:
     Timeout: 5
     Architectures: [ arm64 ]
     Tracing: Active
-    Handler: src/handler.health
     Environment:
       Variables:
         ALLOWED_ORIGIN: !Ref AllowedOrigin
 
 Resources:
-  # HTTP API（安価・高速）
   HttpApi:
     Type: AWS::Serverless::HttpApi
     Properties:
       StageName: !Ref StageName
       CorsConfiguration:
-        AllowOrigins: [ !Ref AllowedOrigin ]
-        AllowMethods: [ GET, POST, OPTIONS ]
-        AllowHeaders: [ Content-Type, Authorization ]
+        AllowOrigins:
+          - !Ref AllowedOrigin
+        AllowMethods:
+          - GET
+          - POST
+          - PATCH
+          - DELETE
+          - OPTIONS
+        AllowHeaders:
+          - Content-Type
+          - Authorization
+          - access-token
+          - client
+          - uid
+          - token-type
+          - expiry
         MaxAge: 86400
 
   HealthFn:
@@ -45,12 +56,6 @@ Resources:
             ApiId: !Ref HttpApi
             Path: /health
             Method: GET
-        OptHealth:
-          Type: HttpApi
-          Properties:
-            ApiId: !Ref HttpApi
-            Path: /health
-            Method: OPTIONS
 
   GuestLoginFn:
     Type: AWS::Serverless::Function
@@ -63,12 +68,6 @@ Resources:
             ApiId: !Ref HttpApi
             Path: /guest/login
             Method: POST
-        OptGuestLogin:
-          Type: HttpApi
-          Properties:
-            ApiId: !Ref HttpApi
-            Path: /guest/login
-            Method: OPTIONS
 
 Outputs:
   ApiInvokeUrl:


### PR DESCRIPTION
### 概要
- ブラウザでのゲストログイン失敗（CORSエラー）を修正。
- `/guest/login` エンドポイントに CORS ヘッダと認証系ヘッダを追加。

### 変更内容
- `handler.mjs`：
  - `corsHeaders()` に `Access-Control-Expose-Headers` とトークン系ヘッダを追加。
  - `guestLogin()` のレスポンスに `access-token`, `client`, `uid`, `token-type`, `expiry` を付与。
  - CORSヘッダを統一的に返すように修正。
- `template.yaml`：
  - `HttpApi.CorsConfiguration.AllowHeaders` にトークン関連ヘッダを追加。

### 動作確認
1. SAM デプロイ実行後、`https://app.genba-tasks.com/login` を開く。
2. DevTools → Network で確認：
   - `OPTIONS /guest/login` が 200
   - `POST /guest/login` の Response Headers に以下が含まれていること  
     - `Access-Control-Allow-Origin: https://app.genba-tasks.com`
     - `Access-Control-Expose-Headers: access-token,client,uid,token-type,expiry`
     - `access-token`, `client`, `uid`, `token-type`, `expiry`
3. 「ゲストユーザーで試す」クリックで `/tasks` へ遷移できる。

### 影響範囲 / リスク
- 既存 `/health` エンドポイントの挙動に影響なし。
- 他の Lambda 関数へは影響なし。
- デプロイ時に CloudFormation スタックの更新が走る。

### ロールバック
- `handler.mjs` の `corsHeaders` / `guestLogin` を以前の実装に戻す。
- 再度 `sam deploy` 実行。

### 補足
- 現在 `curl` では成功するがブラウザで失敗する問題を解消。
- 本修正で preflight（OPTIONS）と POST の両方が正しく CORS 通過する。
