### PR TITLE
feat: Backend自動デプロイワークフローの追加

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,184 @@
+# GitHub Actions ワークフロー設定ガイド
+
+## 概要
+
+このリポジトリには以下の自動化ワークフローが設定されています：
+
+### Backend（Rails API）
+
+1. **CI/CD**
+   - `ci.yml` - テスト・Lint・セキュリティスキャン（PR & main push時）
+   - `deploy-backend.yml` - ECS Fargateへの自動デプロイ（main push時）
+
+### Frontend（React SPA）
+
+1. **deploy-front.yml** - S3 + CloudFrontへの自動デプロイ（main push時）
+
+### その他
+
+1. **deploy-demo-api.yml** - Lambda Demo APIのデプロイ
+2. **aws-oidc-check.yml** - AWS OIDC接続確認
+
+---
+
+## Backend自動デプロイの設定方法
+
+### 前提条件
+
+- AWS ECS Fargate クラスタが既に作成されている
+- ECR リポジトリが作成されている
+- タスク定義が作成されている
+- OIDC による AWS 認証が設定されている
+
+### 必要な GitHub Secrets
+
+以下のSecretsをGitHubリポジトリに設定してください：
+
+**Settings → Secrets and variables → Actions → Secrets**
+
+| Secret名 | 説明 | 例 |
+|---------|------|-----|
+| `AWS_ROLE_ARN` | OIDC認証用のIAMロールARN | `arn:aws:iam::123456789012:role/GitHubActionsRole` |
+
+### 必要な GitHub Variables
+
+以下のVariablesをGitHubリポジトリに設定してください：
+
+**Settings → Secrets and variables → Actions → Variables**
+
+| Variable名 | 説明 | デフォルト値 |
+|-----------|------|-----------|
+| (なし) | 現在はハードコード | - |
+
+### ワークフロー内のハードコード値（要確認・変更）
+
+`deploy-backend.yml`内で以下の値を環境に合わせて変更してください：
+
+```yaml
+env:
+  AWS_REGION: ap-northeast-1              # AWSリージョン
+  ECR_REPOSITORY: genba-tasks-backend     # ECRリポジトリ名
+  ECS_CLUSTER: genba-tasks-cluster        # ECSクラスタ名
+  ECS_SERVICE: genba-tasks-backend-service # ECSサービス名
+  CONTAINER_NAME: backend                 # コンテナ名（タスク定義と一致させる）
+```
+
+### IAMロールに必要な権限
+
+OIDC認証用のIAMロールには以下の権限が必要です：
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecr:GetAuthorizationToken",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ecs:DescribeTaskDefinition",
+        "ecs:RegisterTaskDefinition",
+        "ecs:UpdateService",
+        "ecs:DescribeServices"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:PassRole"
+      ],
+      "Resource": "arn:aws:iam::123456789012:role/ecsTaskExecutionRole"
+    }
+  ]
+}
+```
+
+### デプロイフロー
+
+1. **トリガー**: `backend/**` 配下のファイルが変更されmainブランチにpushされる
+2. **ビルド**: Dockerイメージをビルド（コミットSHA付き）
+3. **プッシュ**: ECRにイメージをプッシュ（タグ: `latest` と `<commit-sha>`）
+4. **タスク定義更新**: 現在のタスク定義をダウンロードし、新しいイメージIDで更新
+5. **デプロイ**: ECSサービスを新しいタスク定義で更新
+6. **待機**: サービスが安定するまで待機（デフロイ完了を確認）
+
+### トラブルシューティング
+
+#### デプロイが失敗する場合
+
+1. **ECRログイン失敗**
+   - IAMロールに`ecr:GetAuthorizationToken`権限があるか確認
+   - AWS_ROLE_ARNが正しいか確認
+
+2. **タスク定義が見つからない**
+   - `ECS_SERVICE`の名前がタスク定義名と一致しているか確認
+   - タスク定義が実際に存在するか確認（AWS Console）
+
+3. **サービス更新失敗**
+   - ECSクラスタ名、サービス名が正しいか確認
+   - IAMロールに`ecs:UpdateService`権限があるか確認
+
+4. **PassRole エラー**
+   - IAMロールに`iam:PassRole`権限があるか確認
+   - 対象のecsTaskExecutionRole ARNが正しいか確認
+
+#### ログの確認方法
+
+GitHub Actions の実行ログ:
+```
+Actions → Deploy Backend (ECS Fargate) → 最新の実行
+```
+
+ECSタスクのログ（CloudWatch Logs）:
+```
+AWS Console → CloudWatch → Logs → /ecs/genba-tasks-backend
+```
+
+---
+
+## Frontend自動デプロイの設定
+
+既存の`deploy-front.yml`が正常に動作しています。詳細は別途ドキュメント参照。
+
+---
+
+## ローカルでのテスト
+
+### Dockerイメージのビルドテスト
+
+```bash
+cd backend
+docker build -t genba-tasks-backend:test --build-arg GIT_SHA=test .
+docker run -p 3000:3000 genba-tasks-backend:test
+```
+
+### ワークフロー構文チェック
+
+```bash
+# actionlint をインストール
+brew install actionlint
+
+# ワークフローファイルをチェック
+actionlint .github/workflows/deploy-backend.yml
+```
+
+---
+
+## 参考リンク
+
+- [GitHub Actions for AWS](https://github.com/aws-actions)
+- [ECS Deploy Task Definition Action](https://github.com/aws-actions/amazon-ecs-deploy-task-definition)
+- [AWS OIDC設定ガイド](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,0 +1,88 @@
+name: Deploy Backend (ECS Fargate)
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - "backend/**"
+      - ".github/workflows/deploy-backend.yml"
+
+env:
+  AWS_REGION: ap-northeast-1
+  ECR_REPOSITORY: genba-tasks-backend
+  ECS_CLUSTER: genba-tasks-cluster
+  ECS_SERVICE: genba-tasks-backend-service
+  CONTAINER_NAME: backend
+
+jobs:
+  deploy:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        working-directory: backend
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          # Docker イメージをビルド
+          docker build \
+            --build-arg GIT_SHA=${{ github.sha }} \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest \
+            .
+
+          # ECR にプッシュ
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+          # 次のステップで使用するため出力
+          echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Download current task definition
+        run: |
+          aws ecs describe-task-definition \
+            --task-definition ${{ env.ECS_SERVICE }} \
+            --query taskDefinition > task-definition.json
+
+      - name: Fill in the new image ID in the Amazon ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: task-definition.json
+          container-name: ${{ env.CONTAINER_NAME }}
+          image: ${{ steps.build-image.outputs.image }}
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: ${{ steps.task-def.outputs.task-definition }}
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+
+      - name: Verify deployment
+        run: |
+          echo "✅ Deployment completed successfully!"
+          echo "Image: ${{ steps.build-image.outputs.image }}"
+          echo "Service: ${{ env.ECS_SERVICE }}"
+          echo "Cluster: ${{ env.ECS_CLUSTER }}"


### PR DESCRIPTION
GitHub ActionsでECS Fargateへの自動デプロイを実装:

## 追加機能

### 自動デプロイワークフロー (.github/workflows/deploy-backend.yml)
- **トリガー**: mainブランチへのpush（backend/**変更時のみ）
- **デプロイフロー**:
  1. Dockerイメージビルド（コミットSHA付き）
  2. ECRへプッシュ（latest + commit-shaタグ）
  3. ECSタスク定義の更新
  4. ECSサービスへのデプロイ
  5. サービス安定化の待機

### 設定ドキュメント (.github/workflows/README.md)
- 必要なGitHub Secrets/Variablesの一覧
- IAMロールの必要権限
- トラブルシューティングガイド
- ローカルテスト方法

## 必要な設定（デプロイ前に実施）

1. **GitHubリポジトリのSecrets設定**:
   - `AWS_ROLE_ARN`: OIDC認証用IAMロールARN

2. **ワークフロー内の環境変数確認**:
   - `ECR_REPOSITORY`: ECRリポジトリ名
   - `ECS_CLUSTER`: ECSクラスタ名
   - `ECS_SERVICE`: ECSサービス名
   - `CONTAINER_NAME`: コンテナ名

3. **IAMロール権限**:
   - ECR: プッシュ・プル権限
   - ECS: タスク定義・サービス更新権限
   - IAM: PassRole権限

## 利点

- ✅ 手動デプロイ不要（mainマージで自動実行）
- ✅ デプロイ履歴の可視化（GitHub Actions）
- ✅ ロールバック可能（ECRに過去イメージ保存）
- ✅ OIDC認証（AWS認証情報不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)