### PR TITLE
refactor: 日付フォーマット関数の重複を解消

### DIFF
--- a/frontend/src/features/priority/PriorityTasksPanel.tsx
+++ b/frontend/src/features/priority/PriorityTasksPanel.tsx
@@ -4,19 +4,10 @@ import useAuth from "../../providers/useAuth";
 import { useUpdateTask } from "../tasks/useUpdateTask";
 import type { Task } from "../../types/task";
 import { useQueryClient } from "@tanstack/react-query";
+import { formatDeadlineForDisplay } from "../../utils/date";
 
 const clamp = (n: number, min = 0, max = 100) =>
   Math.min(Math.max(n ?? 0, min), max);
-
-function fmtDeadline(iso?: string | null) {
-  if (!iso) return "期限なし";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return iso ?? "";
-  const m = d.getMonth() + 1;
-  const day = d.getDate();
-  const dow = "日月火水木金土"[d.getDay()];
-  return `${m}/${day}(${dow})`;
-}
 
 export default function PriorityTasksPanel() {
   const { authed } = useAuth();
@@ -109,7 +100,7 @@ export default function PriorityTasksPanel() {
                   {t.title}
                 </p>
                 <p className="text-xs text-blue-800/70 dark:text-blue-200/70">
-                  {fmtDeadline(t.deadline)}・進捗 {Math.round(t.progress ?? 0)}%
+                  {formatDeadlineForDisplay(t.deadline)}・進捗 {Math.round(t.progress ?? 0)}%
                 </p>
                 <div className="mt-1 h-2 w-full rounded bg-blue-200/70 dark:bg-blue-900/50">
                   <div

--- a/frontend/src/features/tasks/inline/InlineTaskRow.tsx
+++ b/frontend/src/features/tasks/inline/InlineTaskRow.tsx
@@ -15,6 +15,7 @@ import { useTaskDrawer } from "../../drawer/useTaskDrawer";
 import TaskImagePanel from "../image/TaskImagePanel";
 import { brandIso } from "../../../lib/brandIso";
 import { demoImageStore } from "../../../lib/demoImageStore";
+import { toDateInputValue } from "../../../utils/date";
 
 // 新しく作成したコンポーネント
 import { TaskRowEdit } from "./TaskRowEdit";
@@ -30,16 +31,6 @@ const INDENT_STEP = 24;
 const normPid = (v: number | null | undefined) => (v == null ? null : Number(v));
 const samePid = (a: number | null | undefined, b: number | null | undefined) =>
   normPid(a) === normPid(b);
-
-function toDateInputValue(iso?: string | null): string {
-  if (!iso) return "";
-  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${d.getFullYear()}-${mm}-${dd}`;
-}
 
 /** 子タスクは固定: 期限昇順 -> 期限なし -> id昇順 */
 const sortChildrenFixed = (kids: Task[]) => {

--- a/frontend/src/features/tasks/inline/TaskRowDisplay.tsx
+++ b/frontend/src/features/tasks/inline/TaskRowDisplay.tsx
@@ -1,4 +1,5 @@
 import type { TaskNode } from "../../../types";
+import { toDateInputValue } from "../../../utils/date";
 
 interface Props {
   task: TaskNode;
@@ -13,16 +14,6 @@ const STATUS_LABEL: Record<TaskNode["status"], string> = {
   in_progress: "進行中",
   completed: "完了",
 };
-
-function toDateInputValue(iso?: string | null): string {
-  if (!iso) return "";
-  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${d.getFullYear()}-${mm}-${dd}`;
-}
 
 /**
  * タスク表示コンポーネント

--- a/frontend/src/features/tasks/inline/useTaskEditing.ts
+++ b/frontend/src/features/tasks/inline/useTaskEditing.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import type { TaskNode } from "../../../types";
 import { useUpdateTask } from "../useUpdateTask";
 import { brandIso } from "../../../lib/brandIso";
+import { toDateInputValue } from "../../../utils/date";
 
 /**
  * タスク編集用のカスタムフック
@@ -47,15 +48,4 @@ export function useTaskEditing(task: TaskNode) {
     save,
     cancel,
   };
-}
-
-// 日付を input[type="date"] 用の文字列に変換
-function toDateInputValue(iso?: string | null): string {
-  if (!iso) return "";
-  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${d.getFullYear()}-${mm}-${dd}`;
 }

--- a/frontend/src/features/tasks/nest.ts
+++ b/frontend/src/features/tasks/nest.ts
@@ -1,5 +1,6 @@
 // src/features/tasks/nest.ts
 import type { Task, TaskNode } from "../../types";
+import { toDateInputValue } from "../../utils/date";
 
 /** フラット配列を親子ツリー化（depth 付与・children 初期化） */
 export function nestTasks(flat: Task[]): TaskNode[] {
@@ -41,16 +42,7 @@ export function nestTasks(flat: Task[]): TaskNode[] {
  * order_by: "deadline" | "site" | "site,deadline" | "deadline,site"
  * dir は主キーのみに適用
  */
-const toDateInput = (iso?: string | null) => {
-  if (!iso) return "";
-  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const dd = String(d.getDate()).padStart(2, "0");
-  return `${d.getFullYear()}-${mm}-${dd}`;
-};
-const isNullDeadline = (t: { deadline?: string | null }) => !toDateInput(t.deadline);
+const isNullDeadline = (t: { deadline?: string | null }) => !toDateInputValue(t.deadline);
 
 const cmpSite = (a?: string | null, b?: string | null) => {
   const aa = (a ?? "").trim().toLowerCase();
@@ -87,10 +79,10 @@ export function sortRootNodes(
     if (primary === "site") {
       const ds = cmpSite(a.site, b.site);
       if (ds !== 0) return dir === "desc" ? -ds : ds;
-      const da = toDateInput(a.deadline), db = toDateInput(b.deadline);
+      const da = toDateInputValue(a.deadline), db = toDateInputValue(b.deadline);
       if (da !== db) return da < db ? -1 : 1;
     } else {
-      const da = toDateInput(a.deadline), db = toDateInput(b.deadline);
+      const da = toDateInputValue(a.deadline), db = toDateInputValue(b.deadline);
       if (da !== db) {
         const asc = da < db ? -1 : 1;
         return dir === "desc" ? -asc : asc;
@@ -122,10 +114,10 @@ export function sortFlatForUI(
     if (ob === "site") {
       const ds = cmpSite(a.site, b.site);
       if (ds !== 0) return dir === "desc" ? -ds : ds;
-      const da = toDateInput(a.deadline), db = toDateInput(b.deadline);
+      const da = toDateInputValue(a.deadline), db = toDateInputValue(b.deadline);
       if (da !== db) return da < db ? -1 : 1;
     } else {
-      const da = toDateInput(a.deadline), db = toDateInput(b.deadline);
+      const da = toDateInputValue(a.deadline), db = toDateInputValue(b.deadline);
       if (da !== db) {
         const asc = da < db ? -1 : 1;
         return dir === "desc" ? -asc : asc;

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -1,9 +1,44 @@
+/**
+ * ISO日付文字列をYYYY-MM-DD形式に変換
+ * @param iso ISO形式の日付文字列
+ * @returns YYYY-MM-DD形式の文字列、または null
+ */
 export const toYmd = (iso: string | null | undefined): string | null => {
-    if (!iso) return null;
-    const d = new Date(iso);
-    if (Number.isNaN(d.getTime())) return null;
-    const mm = String(d.getMonth() + 1).padStart(2, "0");
-    const dd = String(d.getDate()).padStart(2, "0");
-    return `${d.getFullYear()}-${mm}-${dd}`;
-  };
-  
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+};
+
+/**
+ * ISO日付文字列を input[type="date"] 用の文字列に変換
+ * すでにYYYY-MM-DD形式の場合はそのまま返す
+ * @param iso ISO形式の日付文字列
+ * @returns YYYY-MM-DD形式の文字列、または空文字列
+ */
+export function toDateInputValue(iso?: string | null): string {
+  if (!iso) return "";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) return iso;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${d.getFullYear()}-${mm}-${dd}`;
+}
+
+/**
+ * ISO日付文字列を表示用フォーマット（M/DD(曜日)）に変換
+ * @param iso ISO形式の日付文字列
+ * @returns M/DD(曜日) 形式の文字列、または "期限なし"
+ */
+export function formatDeadlineForDisplay(iso?: string | null): string {
+  if (!iso) return "期限なし";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso ?? "";
+  const m = d.getMonth() + 1;
+  const day = d.getDate();
+  const dow = "日月火水木金土"[d.getDay()];
+  return `${m}/${day}(${dow})`;
+}


### PR DESCRIPTION
## 概要
6つのファイルに重複していた日付フォーマット関数を統一し、`src/utils/date.ts`に集約しました。

## 変更内容

### 統一した関数（`frontend/src/utils/date.ts`）
- `toDateInputValue()` - input[type="date"]用のYYYY-MM-DD形式
- `formatDeadlineForDisplay()` - 表示用のM/DD(曜日)形式  
- `toYmd()` - 既存のnull対応版（保持）

### 重複を削除したファイル
1. `frontend/src/features/tasks/inline/InlineTaskRow.tsx` - `toDateInputValue()`を削除
2. `frontend/src/features/tasks/inline/TaskRowDisplay.tsx` - `toDateInputValue()`を削除
3. `frontend/src/features/tasks/inline/useTaskEditing.ts` - `toDateInputValue()`を削除
4. `frontend/src/features/tasks/nest.ts` - `toDateInput()`を`toDateInputValue()`に統一
5. `frontend/src/features/priority/PriorityTasksPanel.tsx` - `fmtDeadline()`を`formatDeadlineForDisplay()`に統一

## 効果
- コード重複を約50行削除
- Single Source of Truthを実現
- 保守性とテスト容易性が向上
- 一貫性のある命名規則を確立

## テスト
- ✅ TypeScriptの型チェック完了（エラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)