### PR TITLE
chore: .gitignoreの改善とKamal secretsテンプレート追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,22 @@ dist/
 build/
 coverage/
 /package-lock.json
+
+# === バックアップファイル ===
+*.bak
+*.backup
+*.old
+*~
+
+# === エディタの一時ファイル ===
+*.swp
+*.swo
+*.swn
+.*.sw[a-z]
+*.un~
+
+# === IDEの個人設定 ===
+.vscode/settings.json
+.vscode/launch.json
+.idea/workspace.xml
+.idea/tasks.xml

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -31,3 +31,15 @@
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# === Kamal secrets ===
+/.kamal/secrets
+
+# === バックアップファイル ===
+*.bak
+*.old
+*~
+
+# === データベースダンプ ===
+*.sql
+*.dump

--- a/backend/.kamal/secrets.example
+++ b/backend/.kamal/secrets.example
@@ -1,0 +1,17 @@
+# Secrets defined here are available for reference under registry/password, env/secret, builder/secrets,
+# and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
+# password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
+
+# Example of extracting secrets from 1password (or another compatible pw manager)
+# SECRETS=$(kamal secrets fetch --adapter 1password --account your-account --from Vault/Item KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
+# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
+# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
+
+# Use a GITHUB_TOKEN if private repositories are needed for the image
+# GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
+
+# Grab the registry password from ENV
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+
+# Improve security by using a password manager. Never check config/master.key into git!
+RAILS_MASTER_KEY=$(cat config/master.key)


### PR DESCRIPTION
## 概要
誤ってバックアップファイルや一時ファイルがコミットされるのを防ぐため、`.gitignore`のパターンを強化しました。

## 変更内容

### 📝 `.gitignore` (ルート) への追加
```gitignore
# === バックアップファイル ===
*.bak
*.backup
*.old
*~

# === エディタの一時ファイル ===
*.swp
*.swo
*.swn
.*.sw[a-z]
*.un~

# === IDEの個人設定 ===
.vscode/settings.json
.vscode/launch.json
.idea/workspace.xml
.idea/tasks.xml
```

### 🔧 `backend/.gitignore` への追加
```gitignore
# === Kamal secrets ===
/.kamal/secrets

# === バックアップファイル ===
*.bak
*.old
*~

# === データベースダンプ ===
*.sql
*.dump
```

### ✨ `backend/.kamal/secrets.example` の新規作成
- 実際の `.kamal/secrets` ファイルは環境固有のため除外
- 開発者がコピーして使用できるテンプレートを提供
- 機密情報を含まないサンプルファイル

## 📊 効果
- ✅ **バックアップファイルの誤コミットを防止**
  - `*.bak`, `*.old` ファイルが自動的に除外される
- ✅ **エディタ一時ファイルの混入を防止**
  - Vim/Emacsの一時ファイルが除外される
- ✅ **環境固有のKamal secretsファイルを保護**
  - 本番環境のシークレットが誤ってコミットされるのを防ぐ
- ✅ **開発環境のセットアップが容易に**
  - `secrets.example` をコピーして使用可能

## 🔍 背景
Git管理されていた `backend/config/credentials.yml.enc.bak` ファイルの混入を受けて、同様の問題を未然に防ぐための予防措置として実施しました。

## 🧪 テスト
- ✅ .gitignoreの構文チェック
- ✅ 既存ファイルへの影響なし
- ✅ 新しいパターンが正しく機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)