### PR TITLE
fix: DockerビルドのHash Sum mismatchエラーを修正

### DIFF
--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,4 +1,4 @@
-ARG RUBY_VERSION=3.2.3
+ARG RUBY_VERSION=3.2.6
 FROM ruby:${RUBY_VERSION}-slim AS base
 
 ENV LANG=C.UTF-8 \
@@ -9,10 +9,18 @@ ENV LANG=C.UTF-8 \
 
 WORKDIR /rails
 
-RUN apt-get update -y && apt-get install -y --no-install-recommends \
-    bash curl ca-certificates git build-essential pkg-config \
-    default-libmysqlclient-dev default-mysql-client libssl-dev tzdata \
- && rm -rf /var/lib/apt/lists/*
+# 日本のDebianミラーを使用してパッケージインストール
+RUN set -eux; \
+    echo "deb http://ftp.jp.debian.org/debian/ bookworm main" > /etc/apt/sources.list && \
+    echo "deb http://ftp.jp.debian.org/debian/ bookworm-updates main" >> /etc/apt/sources.list && \
+    echo "deb http://security.debian.org/debian-security bookworm-security main" >> /etc/apt/sources.list && \
+    rm -rf /var/lib/apt/lists/*; \
+    apt-get clean; \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends \
+      bash curl ca-certificates git build-essential pkg-config \
+      default-libmysqlclient-dev default-mysql-client libssl-dev tzdata && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN gem install bundler -N
 


### PR DESCRIPTION
## 概要
Dockerビルド時に発生していた「Hash Sum mismatch」エラーを修正しました。

## 変更内容
- Ruby 3.2.3 から 3.2.6 にアップグレード
- 日本のDebianミラー(ftp.jp.debian.org)を使用してパッケージ取得
- セキュリティ更新用にsecurity.debian.orgを追加

## 解決した問題
`docker compose build` 実行時に、deb.debian.orgからのパッケージ取得で頻繁に発生していた以下のエラーが解消されます：
- Hash Sum mismatch
- 404 Not Found

## テスト
- ✅ `docker compose build --no-cache api` が成功することを確認
- ✅ `docker compose up -d` でAPIコンテナが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)