### PR TITLE
security: 本番環境でSSL/TLS通信を強制

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -20,10 +20,10 @@ Rails.application.configure do
   config.active_storage.service = :amazon
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = false
-  config.force_ssl  = false
-  # ※ 将来 HTTPS 化したら true に戻すか、/up だけ除外:
-  # config.ssl_options = { redirect: { exclude: ->(req) { req.path == "/up" } } }
+  config.assume_ssl = true
+  config.force_ssl  = true
+  # ヘルスチェックパスだけSSLリダイレクトから除外
+  config.ssl_options = { redirect: { exclude: ->(req) { req.path == "/up" } } }
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [:request_id]


### PR DESCRIPTION
## 🔒 概要
本番環境でSSL/TLS通信を強制し、重大なセキュリティリスクを解消します。

## ⚠️ セキュリティ上の問題（修正前）
現状、本番環境で以下の設定が無効化されており、**Critical**レベルのセキュリティリスクがありました：
```ruby
config.assume_ssl = false
config.force_ssl  = false
```

### 修正前のリスク
- 🔓 **中間者攻撃（MITM）**: HTTP通信が傍受される可能性
- 🔓 **認証トークンの漏洩**: access-token, client, uid が平文で送信される
- 🔓 **クッキーハイジャック**: セッション情報が盗まれる可能性
- 🔓 **個人情報の漏洩**: メールアドレス、パスワードが平文で通信される

## ✅ 変更内容
`backend/config/environments/production.rb` を修正：

```ruby
# 修正前
config.assume_ssl = false
config.force_ssl  = false

# 修正後
config.assume_ssl = true
config.force_ssl  = true
# ヘルスチェックパスだけSSLリダイレクトから除外
config.ssl_options = { redirect: { exclude: ->(req) { req.path == "/up" } } }
```

### 変更の詳細
1. **`config.assume_ssl = true`**: リバースプロキシ経由のSSL終端を想定
2. **`config.force_ssl = true`**: すべてのHTTPリクエストをHTTPSにリダイレクト
3. **`ssl_options`**: ヘルスチェックエンドポイント `/up` のみHTTPアクセスを許可

## 🎯 期待される効果
- ✅ すべてのAPI通信がHTTPS経由に強制される
- ✅ 認証トークンが暗号化された通信で送信される
- ✅ 中間者攻撃のリスクが大幅に軽減される
- ✅ Rails標準のセキュリティベストプラクティスに準拠

## 🧪 影響範囲
- **本番環境のみ**: 開発環境・テスト環境は影響なし
- **ヘルスチェック**: `/up` エンドポイントはHTTPアクセス可能（ロードバランサー対応）
- **その他すべてのエンドポイント**: HTTPS必須

## 📋 デプロイ前の確認事項
- [ ] ロードバランサー/リバースプロキシでSSL証明書が設定済み
- [ ] HTTPS経由でアプリケーションにアクセス可能
- [ ] フロントエンドのAPIベースURLが `https://` になっている

## 🔗 関連情報
- Rails Guides: [Force SSL](https://guides.rubyonrails.org/configuring.html#config-force-ssl)
- セキュリティ分析: Brakemanスキャンで推奨された対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)