### PR TITLE
refactor: SQLインジェクション警告の解消とCORS設定の改善

### DIFF
--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -113,12 +113,16 @@ class Task < ApplicationRecord
       case order_by
       when "deadline"
         # NULLS LAST 相当（SQLiteでも効く）
+        direction = p[:dir].to_s.downcase == "desc" ? :desc : :asc
         rel.order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END ASC"))
-           .order("deadline #{dir}")
+           .order(deadline: direction)
       when "progress"
-        rel.order(Arel.sql("COALESCE(progress,0) #{dir}"))
+        # Arelの安全なAPIを使用してBrakeman警告を回避
+        direction = p[:dir].to_s.downcase == "desc" ? :desc : :asc
+        rel.order(Arel.sql("COALESCE(progress,0)").send(direction))
       else
-        rel.order("created_at #{dir}")
+        direction = p[:dir].to_s.downcase == "desc" ? :desc : :asc
+        rel.order(created_at: direction)
       end
 
     # ★ 兄弟内は常に position 昇順に（任意の order_by に追加のセカンダリソート）

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -1,6 +1,25 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'https://app.genba-tasks.com', 'http://localhost:5173', 'http://127.0.0.1:5173'
+    # 環境変数から許可オリジンを取得
+    allowed_origins = [
+      ENV.fetch("FRONTEND_URL", "https://app.genba-tasks.com")
+    ]
+
+    # 開発環境では追加のオリジンを許可
+    if Rails.env.development?
+      allowed_origins += [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173"
+      ]
+    end
+
+    # ステージング環境などの追加オリジン（オプション）
+    if ENV["STAGING_FRONTEND_URL"].present?
+      allowed_origins << ENV["STAGING_FRONTEND_URL"]
+    end
+
+    origins allowed_origins
+
     resource '*',
       headers: :any,
       methods: %i[get post put patch delete options head],


### PR DESCRIPTION
## 🔧 概要
コード品質とセキュリティを向上させるため、以下2つの改善を実施しました：
1. Brakemanが検出したSQLインジェクション警告の解消
2. CORS設定の環境変数化による運用の柔軟性向上

---

## 🛡️ **1. SQLインジェクション警告の解消**

### 問題
Brakemanスキャンで以下の警告が検出されていました：

```
[Medium] SQL Injection - app/models/task.rb:119
Possible SQL injection
```

**該当コード（修正前）**:
```ruby
when "progress"
  rel.order(Arel.sql("COALESCE(progress,0) #{dir}"))
```

### 問題の詳細
- 実際には110行目でホワイトリスト検証済み（`%w[asc desc]`）
- しかし静的解析ツールは検証ロジックを追跡できず警告を出していた
- False Positiveだが、より安全なコードに改善する余地があった

### 解決策
Arelの安全なAPIを使用して**文字列補間を完全に排除**：

```ruby
when "progress"
  # Arelの安全なAPIを使用してBrakeman警告を回避
  direction = p[:dir].to_s.downcase == "desc" ? :desc : :asc
  rel.order(Arel.sql("COALESCE(progress,0)").send(direction))
```

### 追加の改善
他のソート処理も同様にリファクタリング：

**deadline ソート**:
```ruby
# 修正前
rel.order("deadline #{dir}")

# 修正後
direction = p[:dir].to_s.downcase == "desc" ? :desc : :asc
rel.order(deadline: direction)
```

**created_at ソート**:
```ruby
# 修正前
rel.order("created_at #{dir}")

# 修正後
direction = p[:dir].to_s.downcase == "desc" ? :desc : :asc
rel.order(created_at: direction)
```

### 効果
- ✅ **Brakeman警告が0件に**: `Security Warnings: 0`
- ✅ **より明示的**: ソート方向の意図が明確
- ✅ **保守性向上**: 文字列補間による誤りを防止
- ✅ **ベストプラクティス**: Railsの推奨パターンに準拠

---

## 🌐 **2. CORS設定の環境変数化**

### 問題
CORSの許可オリジンがハードコードされており、環境ごとの柔軟な設定ができませんでした：

**修正前**:
```ruby
origins 'https://app.genba-tasks.com', 'http://localhost:5173', 'http://127.0.0.1:5173'
```

**課題**:
- ❌ ステージング環境に対応できない
- ❌ プレビューデプロイに対応できない
- ❌ 環境ごとに異なるドメインを設定できない

### 解決策
環境変数ベースの動的な設定に変更：

```ruby
# 環境変数から許可オリジンを取得
allowed_origins = [
  ENV.fetch("FRONTEND_URL", "https://app.genba-tasks.com")
]

# 開発環境では追加のオリジンを許可
if Rails.env.development?
  allowed_origins += [
    "http://localhost:5173",
    "http://127.0.0.1:5173"
  ]
end

# ステージング環境などの追加オリジン（オプション）
if ENV["STAGING_FRONTEND_URL"].present?
  allowed_origins << ENV["STAGING_FRONTEND_URL"]
end

origins allowed_origins
```

### 使用例

#### 本番環境
```bash
FRONTEND_URL=https://app.genba-tasks.com
```

#### ステージング環境
```bash
FRONTEND_URL=https://staging.genba-tasks.com
```

#### ステージング + プレビュー環境
```bash
FRONTEND_URL=https://staging.genba-tasks.com
STAGING_FRONTEND_URL=https://pr-123.genba-tasks.com
```

#### 開発環境
```bash
# 環境変数不要（デフォルトでlocalhost:5173が許可される）
```

### 効果
- ✅ **環境ごとに柔軟な設定**: 本番・ステージング・開発で異なるURLを設定可能
- ✅ **プレビューデプロイ対応**: PR単位のプレビュー環境にも対応
- ✅ **開発体験の維持**: 開発環境では従来通りlocalhostが自動許可
- ✅ **セキュリティ維持**: 許可されたオリジンのみアクセス可能

---

## 🧪 **検証結果**

### セキュリティスキャン
```bash
$ bundle exec brakeman -q
Security Warnings: 0
No warnings found
```

### CORS動作確認
- ✅ 開発環境: localhost:5173からのアクセス成功
- ✅ 環境変数: FRONTEND_URLが正しく読み込まれる
- ✅ デフォルト値: 環境変数未設定時も正常動作

### 影響確認
- ✅ 既存のタスクソート機能: 正常動作
- ✅ API認証: 正常動作
- ✅ CORS制限: 正しく機能

---

## 📊 **コード品質の改善**

| 指標 | 修正前 | 修正後 |
|------|--------|--------|
| Brakeman警告 | 1件 | **0件** ✅ |
| 文字列補間（SQL） | 3箇所 | **0箇所** ✅ |
| ハードコード設定 | 1箇所 | **0箇所** ✅ |
| 環境対応力 | 本番・開発のみ | **本番・ステージング・開発** ✅ |

---

## 📋 **デプロイ時の注意事項**

### 環境変数（オプション）
必須ではありませんが、環境ごとに異なるフロントエンドURLを使う場合は設定してください：

```bash
# .kamal/secrets または環境変数
FRONTEND_URL=https://app.genba-tasks.com

# ステージング環境がある場合（オプション）
STAGING_FRONTEND_URL=https://staging.genba-tasks.com
```

**デフォルト値があるため、環境変数未設定でも動作します。**

---

## 🎯 **この変更の意義**

### セキュリティ
- Brakemanの警告を完全に解消し、より安全なコードに
- 静的解析ツールでも問題なしと判断されるコード品質

### 保守性
- 文字列補間を排除し、将来的なバグを防止
- 環境変数で設定を管理し、コード変更なしで環境対応

### 開発体験
- ステージング環境やプレビュー環境への対応が容易に
- 開発環境では従来通り快適に作業可能

---

## 🔗 **関連情報**
- Rails Guides: [Active Record Query Interface](https://guides.rubyonrails.org/active_record_querying.html)
- Brakeman: [SQL Injection](https://brakemanscanner.org/docs/warning_types/sql_injection/)
- Rack CORS: [Configuration](https://github.com/cyu/rack-cors#configuration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)