### PR TITLE
fix: クリックアウトサイドで保存後に編集モードを終了

### DIFF
--- a/frontend/src/features/tasks/inline/TaskRowEdit.tsx
+++ b/frontend/src/features/tasks/inline/TaskRowEdit.tsx
@@ -60,6 +60,7 @@ export function TaskRowEdit({ task, onCancel }: Props) {
     const handleClickOutside = (event: MouseEvent) => {
       if (formRef.current && !formRef.current.contains(event.target as Node)) {
         save();
+        onCancel(); // 編集モードを終了
       }
     };
 
@@ -68,7 +69,7 @@ export function TaskRowEdit({ task, onCancel }: Props) {
     return () => {
       document.removeEventListener("mousedown", handleClickOutside);
     };
-  }, [save]);
+  }, [save, onCancel]);
 
   return (
     <form


### PR DESCRIPTION
## Summary
- タスク編集時に画面外をクリックした際、`save()`は呼ばれるが`onCancel()`が呼ばれず編集モードが終了しない問題を修正
- クリックアウトサイドのハンドラーで`save()`後に`onCancel()`を呼び出すように変更
- `useEffect`の依存配列に`onCancel`を追加

## 変更内容
**ファイル**: `frontend/src/features/tasks/inline/TaskRowEdit.tsx`

- クリックアウトサイド時に`save()`だけでなく`onCancel()`も実行
- これにより保存後に編集モードが正しく終了する

## 影響範囲
上位タスク（親タスク）とサブタスク（子タスク）の両方に適用されます。

## Test plan
- [x] 型チェック通過
- [ ] タスクをダブルクリックして編集モード開始
- [ ] タイトルや期限を変更
- [ ] 保存ボタンを押さず画面外をクリック
- [ ] 変更が保存され、編集モードが終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)