### PR TITLE
feat: 期限の視認性を大幅に向上

### DIFF
--- a/frontend/src/features/priority/PriorityTasksPanel.tsx
+++ b/frontend/src/features/priority/PriorityTasksPanel.tsx
@@ -4,7 +4,7 @@ import useAuth from "../../providers/useAuth";
 import { useUpdateTask } from "../tasks/useUpdateTask";
 import type { Task } from "../../types/task";
 import { useQueryClient } from "@tanstack/react-query";
-import { formatDeadlineForDisplay } from "../../utils/date";
+import { formatDeadlineForDisplay, getDeadlineUrgency, formatDaysUntilDeadline } from "../../utils/date";
 
 const clamp = (n: number, min = 0, max = 100) =>
   Math.min(Math.max(n ?? 0, min), max);
@@ -99,9 +99,27 @@ export default function PriorityTasksPanel() {
                 >
                   {t.title}
                 </p>
-                <p className="text-xs text-blue-800/70 dark:text-blue-200/70">
-                  {formatDeadlineForDisplay(t.deadline)}・進捗 {Math.round(t.progress ?? 0)}%
-                </p>
+                <div className="flex items-center gap-2 mt-0.5">
+                  <p className="text-xs text-blue-800/70 dark:text-blue-200/70">
+                    {formatDeadlineForDisplay(t.deadline)}
+                  </p>
+                  <span
+                    className={[
+                      "text-xs px-1.5 py-0.5 rounded font-semibold",
+                      getDeadlineUrgency(t.deadline) === "overdue" && "bg-red-500 text-white",
+                      getDeadlineUrgency(t.deadline) === "urgent" && "bg-orange-500 text-white",
+                      getDeadlineUrgency(t.deadline) === "warning" && "bg-yellow-500 text-white",
+                      getDeadlineUrgency(t.deadline) === "normal" && "bg-blue-500 text-white",
+                    ]
+                      .filter(Boolean)
+                      .join(" ")}
+                  >
+                    {formatDaysUntilDeadline(t.deadline)}
+                  </span>
+                  <span className="text-xs text-blue-800/70 dark:text-blue-200/70">
+                    進捗 {Math.round(t.progress ?? 0)}%
+                  </span>
+                </div>
                 <div className="mt-1 h-2 w-full rounded bg-blue-200/70 dark:bg-blue-900/50">
                   <div
                     className="h-2 rounded bg-blue-600 dark:bg-blue-400"

--- a/frontend/src/features/tasks/inline/TaskRowDisplay.tsx
+++ b/frontend/src/features/tasks/inline/TaskRowDisplay.tsx
@@ -1,5 +1,5 @@
 import type { TaskNode } from "../../../types";
-import { toDateInputValue } from "../../../utils/date";
+import { toDateInputValue, getDeadlineUrgency, formatDaysUntilDeadline } from "../../../utils/date";
 
 interface Props {
   task: TaskNode;
@@ -15,11 +15,24 @@ const STATUS_LABEL: Record<TaskNode["status"], string> = {
   completed: "完了",
 };
 
+// 期限の緊急度に応じたスタイル
+const URGENCY_STYLES = {
+  overdue: "bg-red-100 text-red-800 border-red-300 font-semibold",
+  urgent: "bg-orange-100 text-orange-800 border-orange-300 font-semibold",
+  warning: "bg-yellow-100 text-yellow-800 border-yellow-300",
+  normal: "bg-gray-100 text-gray-700 border-gray-300",
+  none: "bg-gray-100 text-gray-500 border-gray-300",
+};
+
 /**
  * タスク表示コンポーネント
  * タイトル、期限、ステータス、現場名を表示
  */
 export function TaskRowDisplay({ task, isParent, titleRef, onTitleClick, onTitleKeyDown }: Props) {
+  const urgency = getDeadlineUrgency(task.deadline);
+  const daysUntilText = formatDaysUntilDeadline(task.deadline);
+  const deadlineDate = task.deadline ? toDateInputValue(task.deadline) : null;
+
   return (
     <>
       <div
@@ -47,12 +60,33 @@ export function TaskRowDisplay({ task, isParent, titleRef, onTitleClick, onTitle
         </span>
       </div>
 
-      <div className="mt-1 flex flex-wrap items-center gap-x-4 gap-y-1 text-[13px] text-gray-600">
-        <span>期限: {task.deadline ? toDateInputValue(task.deadline) : "—"}</span>
-        <span data-testid={`task-status-${task.id}`} data-status={task.status}>
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px]">
+        {/* 期限バッジ */}
+        {deadlineDate && (
+          <span
+            className={[
+              "inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs",
+              URGENCY_STYLES[urgency],
+            ].join(" ")}
+            data-testid={`task-deadline-${task.id}`}
+            data-urgency={urgency}
+          >
+            <span>📅</span>
+            <span>{deadlineDate}</span>
+            <span className="font-semibold">({daysUntilText})</span>
+          </span>
+        )}
+        {!deadlineDate && (
+          <span className="text-gray-500">期限: —</span>
+        )}
+
+        {/* ステータス */}
+        <span data-testid={`task-status-${task.id}`} data-status={task.status} className="text-gray-600">
           ステータス: {STATUS_LABEL[task.status]}
         </span>
-        {task.site ? <span>現場名: {task.site}</span> : null}
+
+        {/* 現場名 */}
+        {task.site ? <span className="text-gray-600">現場名: {task.site}</span> : null}
       </div>
     </>
   );

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -42,3 +42,55 @@ export function formatDeadlineForDisplay(iso?: string | null): string {
   const dow = "日月火水木金土"[d.getDay()];
   return `${m}/${day}(${dow})`;
 }
+
+/**
+ * 期限までの残り日数を計算
+ * @param iso ISO形式の日付文字列
+ * @returns 残り日数（負の値は期限切れ）、期限なしの場合はnull
+ */
+export function getDaysUntilDeadline(iso?: string | null): number | null {
+  if (!iso) return null;
+  const deadline = new Date(iso);
+  if (Number.isNaN(deadline.getTime())) return null;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  deadline.setHours(0, 0, 0, 0);
+
+  const diffTime = deadline.getTime() - today.getTime();
+  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+
+  return diffDays;
+}
+
+/**
+ * 期限の緊急度を判定
+ * @param iso ISO形式の日付文字列
+ * @returns "overdue" | "urgent" | "warning" | "normal" | "none"
+ */
+export function getDeadlineUrgency(iso?: string | null): "overdue" | "urgent" | "warning" | "normal" | "none" {
+  const daysUntil = getDaysUntilDeadline(iso);
+
+  if (daysUntil === null) return "none";
+  if (daysUntil < 0) return "overdue"; // 期限切れ
+  if (daysUntil <= 3) return "urgent"; // 3日以内
+  if (daysUntil <= 7) return "warning"; // 7日以内
+
+  return "normal";
+}
+
+/**
+ * 期限を「残り○日」形式でフォーマット
+ * @param iso ISO形式の日付文字列
+ * @returns "残り○日" または "期限切れ" または "期限なし"
+ */
+export function formatDaysUntilDeadline(iso?: string | null): string {
+  const daysUntil = getDaysUntilDeadline(iso);
+
+  if (daysUntil === null) return "期限なし";
+  if (daysUntil < 0) return `期限切れ（${Math.abs(daysUntil)}日超過）`;
+  if (daysUntil === 0) return "今日が期限";
+  if (daysUntil === 1) return "明日が期限";
+
+  return `残り${daysUntil}日`;
+}


### PR DESCRIPTION
## 概要
施工管理の現場で期限を見逃さないよう、期限表示の視認性を大幅に向上させました。

## 変更内容

### 📅 期限の緊急度判定ロジック (`src/utils/date.ts`)
- `getDaysUntilDeadline()` - 期限までの残り日数を計算
- `getDeadlineUrgency()` - 緊急度を5段階で判定
  - `overdue`: 期限切れ
  - `urgent`: 3日以内
  - `warning`: 7日以内
  - `normal`: 8日以降
  - `none`: 期限なし
- `formatDaysUntilDeadline()` - 「残り○日」形式でフォーマット

### 🎨 タスク表示の改善 (`TaskRowDisplay.tsx`)
期限を色分けバッジで表示：
- 🔴 **赤色**: 期限切れ（超過日数も表示）
- 🟠 **オレンジ色**: 3日以内（緊急）
- 🟡 **黄色**: 7日以内（注意）
- ⚪ **グレー**: それ以外（通常）

その他の改善：
- 📅 カレンダーアイコン付き
- 「残り○日」を太字で強調表示
- バッジ形式で周囲から独立して目立つデザイン

### 📌 優先タスクパネルの改善 (`PriorityTasksPanel.tsx`)
- タスクリストと同様の色分けバッジを適用
- より目立つ背景色で緊急度を表現

## スクリーンショット
期限が近いタスクは自動的に色分けされ、残り日数が明示されます。

## 効果
- ✅ 一目で期限の緊急度が判断できる
- ✅ 具体的な残り日数が常に表示される
- ✅ 期限切れタスクは超過日数も表示
- ✅ 施工管理の現場で期限を見逃すリスクが減少

## テスト
- [x] 型チェック通過
- [x] ビルド成功
- [x] 期限切れタスクの表示確認
- [x] 緊急タスク（3日以内）の表示確認
- [x] 注意タスク（7日以内）の表示確認
- [x] 通常タスクの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)