### PR TITLE
feat: サイドバーに現場一覧機能を追加

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,47 +1,155 @@
 // src/components/Sidebar.tsx
-import { NavLink } from "react-router-dom";
+import { NavLink, useSearchParams } from "react-router-dom";
+import { useMemo, useState } from "react";
+import { useFilteredTasks } from "../features/tasks/useTasks";
+import useAuth from "../providers/useAuth";
 
 const Sidebar = () => {
+  const { authed } = useAuth();
+  const DEMO = import.meta.env.VITE_DEMO_MODE === "true";
+  const enabled = authed || DEMO;
+
+  const [sp, setSp] = useSearchParams();
+  const [showTasksLinks, setShowTasksLinks] = useState(true);
+  const [showSitesLinks, setShowSitesLinks] = useState(true);
+
+  // 全タスクを取得して現場一覧を作成
+  const { data: allTasks = [] } = useFilteredTasks({}, enabled);
+
+  // 現場ごとのタスク数を集計（追加順=id順）
+  const sitesWithCount = useMemo(() => {
+    const siteMap = new Map<string, { count: number; firstId: number }>();
+
+    allTasks.forEach((task) => {
+      if (task.site && task.site.trim()) {
+        const site = task.site.trim();
+        const existing = siteMap.get(site);
+        if (existing) {
+          existing.count++;
+          // より小さいIDを保持（追加順の早い方）
+          existing.firstId = Math.min(existing.firstId, task.id);
+        } else {
+          siteMap.set(site, { count: 1, firstId: task.id });
+        }
+      }
+    });
+
+    // 追加順（firstId昇順）でソート
+    return Array.from(siteMap.entries())
+      .map(([site, data]) => ({ site, count: data.count, firstId: data.firstId }))
+      .sort((a, b) => a.firstId - b.firstId);
+  }, [allTasks]);
+
+  const currentSite = sp.get("site") ?? "";
+
+  const selectSite = (site: string) => {
+    const next = new URLSearchParams(sp);
+    if (site) {
+      next.set("site", site);
+    } else {
+      next.delete("site");
+    }
+    setSp(next, { replace: true });
+  };
+
   return (
     <aside
       className={[
         "fixed left-0 top-14",
-        // ↓ 幅を細く（旧: w-56 lg:w-64）
         "w-44 md:w-48 lg:w-52",
         "h-[calc(100vh-3.5rem)]",
         "bg-gray-100/80 backdrop-blur-0",
         "border-r shadow-md",
         "overflow-y-auto",
-        // ↓ 余白も少しだけ詰める
         "p-3 md:p-3.5",
         "z-40",
       ].join(" ")}
     >
       <nav className="flex flex-col gap-3 text-[14px] md:text-[15px]">
-        <NavLink
-          to="/tasks"
-          className={({ isActive }) =>
-            isActive ? "font-semibold text-blue-700" : "hover:underline"
-          }
-        >
-          タスク
-        </NavLink>
-        <NavLink
-          to="/account"
-          className={({ isActive }) =>
-            isActive ? "font-semibold text-blue-700" : "hover:underline"
-          }
-        >
-          アカウント
-        </NavLink>
-        <NavLink
-          to="/help"
-          className={({ isActive }) =>
-            isActive ? "font-semibold text-blue-700" : "hover:underline"
-          }
-        >
-          ヘルプ
-        </NavLink>
+        {/* タスクセクション - 折りたたみ可能 */}
+        <div>
+          <button
+            onClick={() => setShowTasksLinks(!showTasksLinks)}
+            className="flex items-center gap-1 w-full text-left font-medium mb-2 hover:text-blue-700"
+          >
+            <span className="text-xs">{showTasksLinks ? "▼" : "▶"}</span>
+            <span>ページ</span>
+          </button>
+          {showTasksLinks && (
+            <div className="flex flex-col gap-2 ml-4">
+              <NavLink
+                to="/tasks"
+                className={({ isActive }) =>
+                  isActive ? "font-semibold text-blue-700" : "hover:underline"
+                }
+              >
+                タスク
+              </NavLink>
+              <NavLink
+                to="/account"
+                className={({ isActive }) =>
+                  isActive ? "font-semibold text-blue-700" : "hover:underline"
+                }
+              >
+                アカウント
+              </NavLink>
+              <NavLink
+                to="/help"
+                className={({ isActive }) =>
+                  isActive ? "font-semibold text-blue-700" : "hover:underline"
+                }
+              >
+                ヘルプ
+              </NavLink>
+            </div>
+          )}
+        </div>
+
+        {/* 現場一覧セクション - 折りたたみ可能 */}
+        <div className="border-t pt-3">
+          <button
+            onClick={() => setShowSitesLinks(!showSitesLinks)}
+            className="flex items-center gap-1 w-full text-left font-medium mb-2 hover:text-blue-700"
+          >
+            <span className="text-xs">{showSitesLinks ? "▼" : "▶"}</span>
+            <span>📍 現場一覧</span>
+          </button>
+          {showSitesLinks && (
+            <div className="flex flex-col gap-1.5 ml-4">
+              {/* すべての現場を一番上に */}
+              <button
+                onClick={() => selectSite("")}
+                className={[
+                  "text-left px-2 py-1 rounded text-sm hover:bg-gray-200 transition-colors",
+                  !currentSite ? "bg-blue-100 font-semibold text-blue-700" : "",
+                ].join(" ")}
+              >
+                <span className="block truncate">すべての現場</span>
+                <span className="text-xs text-gray-500">({allTasks.length})</span>
+              </button>
+
+              {/* 各現場（追加順） */}
+              {sitesWithCount.map(({ site, count }) => (
+                <button
+                  key={site}
+                  onClick={() => selectSite(site)}
+                  className={[
+                    "text-left px-2 py-1 rounded text-sm hover:bg-gray-200 transition-colors",
+                    currentSite === site ? "bg-blue-100 font-semibold text-blue-700" : "",
+                  ].join(" ")}
+                  title={site}
+                >
+                  <span className="block truncate">{site}</span>
+                  <span className="text-xs text-gray-500">({count})</span>
+                </button>
+              ))}
+
+              {sitesWithCount.length === 0 && (
+                <p className="text-xs text-gray-500 px-2">現場がありません</p>
+              )}
+            </div>
+          )}
+        </div>
       </nav>
     </aside>
   );


### PR DESCRIPTION
## 概要
施工管理の効率化のため、サイドバーに現場別フィルター機能を追加しました。フィルターバーより直感的に現場を切り替えられます。

## 実装内容

### 📍 現場一覧セクション

#### 主な機能
- **自動抽出**: 既存タスクから現場名を自動的に抽出
- **タスク数表示**: 各現場のタスク数を括弧内に表示
- **すべての現場**: 一番上に配置し、全タスクを表示
- **追加順表示**: 現場は追加順（ID昇順）でソート
- **ハイライト**: 選択中の現場は背景色で強調

#### UI設計
```
📍 現場一覧
  ├─ すべての現場 (20)
  ├─ 新宿ビル改修工事 (5)
  ├─ 渋谷マンション建設 (12)
  └─ 池袋商業施設 (3)
```

### 🔽 折りたたみ機能

両方のセクションを折りたたみ可能にし、サイドバーをコンパクトに保てます：
- **ページセクション**: タスク / アカウント / ヘルプ
- **現場一覧セクション**: 現場リスト

▼/▶ アイコンで視覚的に分かりやすく表示

### 🔄 既存機能との統合

- URLパラメータ `?site=現場名` を更新
- 既存のフィルター機能と完全に統合
- フィルターバーとサイドバーが連動

## 使い方

### 基本操作
1. サイドバーの「📍 現場一覧」を開く
2. 表示したい現場をクリック
3. タスクリストが自動的に絞り込まれる
4. 「すべての現場」で全タスクを表示

### 折りたたみ
- セクション名の左の▼/▶ をクリック
- 使わないセクションを折りたたんでスペースを節約

## 技術的な実装

### データ取得
- `useFilteredTasks`で全タスクを取得
- `useMemo`で効率的に現場一覧を生成
- タスク数と最初のID（追加順）を集計

### ソートロジック
```typescript
// 追加順（firstId昇順）でソート
.sort((a, b) => a.firstId - b.firstId)
```

### URL操作
- `useSearchParams`でURLパラメータを管理
- 選択した現場を`?site=`パラメータに反映
- 既存のフィルター機能と連携

## Before / After

### Before（改善前）
- フィルターバーで現場名を入力
- 現場の一覧が見えない
- タスク数が分からない

### After（改善後）
- サイドバーでワンクリック切り替え
- すべての現場が一覧表示
- 各現場のタスク数が一目で分かる

## テスト
- [x] 型チェック通過
- [x] ビルド成功
- [x] 現場一覧の表示確認
- [x] 現場選択でフィルター動作確認
- [x] 折りたたみ機能の動作確認
- [x] URLパラメータ連携確認

## 効果
- ✅ フィルターバーより直感的な操作
- ✅ 各現場のタスク数を一目で把握
- ✅ 現場ごとの管理が効率化
- ✅ コンパクトな折りたたみUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)