### PR TITLE
fix: サイドバーの現場一覧から📍アイコンを削除

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -112,7 +112,7 @@ const Sidebar = () => {
             className="flex items-center gap-1 w-full text-left font-medium mb-2 hover:text-blue-700"
           >
             <span className="text-xs">{showSitesLinks ? "▼" : "▶"}</span>
-            <span>📍 現場一覧</span>
+            <span>現場一覧</span>
           </button>
           {showSitesLinks && (
             <div className="flex flex-col gap-1.5 ml-4">


### PR DESCRIPTION
## Summary
- サイドバーの「📍 現場一覧」から絵文字アイコンを削除
- シンプルに「現場一覧」のみを表示

## Changes
- `frontend/src/components/Sidebar.tsx`: 115行目の「📍 現場一覧」を「現場一覧」に変更

## Notes
現場一覧で絞り込んだ際にタスク一覧も自動的に絞り込まれる機能は既に実装済みであることを確認しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)