### PR TITLE
fix: サイドバーの現場選択時にタスク一覧に反映されるように修正

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 // src/components/Sidebar.tsx
-import { NavLink, useSearchParams } from "react-router-dom";
+import { NavLink, useSearchParams, useNavigate, useLocation } from "react-router-dom";
 import { useMemo, useState } from "react";
 import { useFilteredTasks } from "../features/tasks/useTasks";
 import useAuth from "../providers/useAuth";
@@ -9,7 +9,9 @@ const Sidebar = () => {
   const DEMO = import.meta.env.VITE_DEMO_MODE === "true";
   const enabled = authed || DEMO;
 
-  const [sp, setSp] = useSearchParams();
+  const [sp] = useSearchParams();
+  const navigate = useNavigate();
+  const location = useLocation();
   const [showTasksLinks, setShowTasksLinks] = useState(true);
   const [showSitesLinks, setShowSitesLinks] = useState(true);
 
@@ -49,7 +51,13 @@ const Sidebar = () => {
     } else {
       next.delete("site");
     }
-    setSp(next, { replace: true });
+
+    // /tasksページ以外にいる場合は、/tasksに遷移する
+    if (location.pathname !== "/tasks") {
+      navigate(`/tasks?${next.toString()}`, { replace: false });
+    } else {
+      navigate(`?${next.toString()}`, { replace: true });
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- サイドバーで現場を選択した際に、タスク一覧に絞り込みが反映されるように修正
- 現場選択時に自動的に/tasksページに遷移する機能を追加

## Changes
- `frontend/src/components/Sidebar.tsx`:
  - `useNavigate`と`useLocation`フックを追加
  - `selectSite`関数を修正して、/tasksページ以外にいる場合は/tasksに遷移
  - 既に/tasksページにいる場合はURLパラメータのみ更新

## Problem Solved
現場一覧で現場を選択しても、タスク一覧に絞り込みが反映されない問題を解決しました。

### 修正前の問題
- /accountや/helpページで現場を選択してもタスク一覧に反映されなかった
- URLパラメータは変更されるが、/tasksページにいないため効果がなかった

### 修正後の動作
- どのページからでも現場を選択すると/tasksページに遷移
- URLに`?site=現場名`パラメータが追加される
- タスク一覧が選択した現場のタスクのみに絞り込まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)