### PR TITLE
fix: サイドバーの現場選択時にタスク一覧が正しくフィルタされるように修正

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -46,6 +46,13 @@ const Sidebar = () => {
 
   const selectSite = (site: string) => {
     const next = new URLSearchParams(sp);
+
+    // 他のフィルターパラメータをクリア
+    next.delete("status");
+    next.delete("progress_min");
+    next.delete("progress_max");
+    next.delete("parents_only");
+
     if (site) {
       next.set("site", site);
     } else {
@@ -56,7 +63,7 @@ const Sidebar = () => {
     if (location.pathname !== "/tasks") {
       navigate(`/tasks?${next.toString()}`, { replace: false });
     } else {
-      navigate(`?${next.toString()}`, { replace: true });
+      navigate(`?${next.toString()}`, { replace: false });
     }
   };
 


### PR DESCRIPTION
## 概要
サイドバーで現場名をクリックしてもタスク一覧がフィルタされない問題を修正しました。

## 問題
- サイドバーの現場一覧から現場を選択しても、タスク一覧が更新されない
- URLパラメータは更新されているが、React Routerが変更を検知していなかった

## 修正内容
1. **`navigate`の`replace`オプションを`false`に変更**
   - `replace: true`を使用していたため、ブラウザ履歴に記録されず、React Routerが再レンダリングをトリガーしていなかった
   - `replace: false`に変更することで、確実にURLの変更を検知するようになった

2. **現場選択時に他のフィルターをクリア**
   - 現場選択時に`status`、`progress_min`、`progress_max`、`parents_only`などのフィルターをクリア
   - 他のフィルターが干渉することを防ぐ

## テスト方法
1. サイドバーの現場名をクリック
2. タスク一覧が選択した現場のタスクのみに絞り込まれることを確認
3. 「すべての現場」をクリックすると全タスクが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)