### PR TITLE
優先タスクパネルのUI改善（折りたたみ・件数設定・幅調整） #187

### DIFF
--- a/backend/app/controllers/api/tasks_controller.rb
+++ b/backend/app/controllers/api/tasks_controller.rb
@@ -127,7 +127,9 @@ render json: scope.with_attached_image.as_json(only: SELECT_FIELDS, methods: [:i
 
     # GET /api/tasks/priority
     def priority
-      tasks = current_user.tasks.priority_order
+      limit = (params[:limit] || 5).to_i
+      limit = [[limit, 1].max, 50].min # 1-50の範囲に制限
+      tasks = current_user.tasks.priority_order(limit: limit)
       render json: tasks.as_json(only: SELECT_FIELDS)
     end
 

--- a/backend/app/models/task.rb
+++ b/backend/app/models/task.rb
@@ -53,11 +53,11 @@ class Task < ApplicationRecord
   # -----------------------------------------------
 
   # 優先タスク（未完了/期限→進捗）
-  scope :priority_order, -> {
+  scope :priority_order, ->(limit: 5) {
     where.not(status: :completed)
       .order(Arel.sql("CASE WHEN deadline IS NULL THEN 1 ELSE 0 END ASC"))
       .order(:deadline, :progress)
-      .limit(5)
+      .limit(limit)
   }
 
   # ===== 絞り込み・並び替え =====

--- a/frontend/src/features/priority/usePriorityTasks.ts
+++ b/frontend/src/features/priority/usePriorityTasks.ts
@@ -3,15 +3,17 @@ import { useQuery } from "@tanstack/react-query";
 import api from "../../lib/apiClient";
 import type { Task } from "../../types/task";
 
-async function fetchPriorityTasks(): Promise<Task[]> {
-  const { data } = await api.get<Task[]>("/tasks/priority");
+async function fetchPriorityTasks(limit: number): Promise<Task[]> {
+  const { data } = await api.get<Task[]>("/tasks/priority", {
+    params: { limit },
+  });
   return data;
 }
 
-export function usePriorityTasks(enabled = true) {
+export function usePriorityTasks(enabled = true, limit = 5) {
   return useQuery({
-    queryKey: ["priorityTasks"],
-    queryFn: fetchPriorityTasks,
+    queryKey: ["priorityTasks", limit],
+    queryFn: () => fetchPriorityTasks(limit),
     enabled,
     staleTime: 0,
     refetchInterval: 1000,


### PR DESCRIPTION
## 概要
優先タスクパネル（PriorityTasksPanel）のユーザビリティを向上させる機能を実装しました。

Closes #187

## 主な変更点

### 1. 折りたたみ機能 ✅
- パネルの表示/非表示を切り替えるボタンを追加
- 折りたたみ状態をLocalStorageに保存して次回訪問時も維持
- アニメーション付きのスムーズな開閉（SVGアイコンが回転）

### 2. 表示件数の設定機能 ✅
- 件数選択ドロップダウンを追加（3、5、10、15件から選択可能）
- 設定をLocalStorageに保存
- バックエンドAPIにlimitパラメータを追加（1-50件の範囲で制限）

### 3. パネル幅の調整機能 ✅
- 左端のリサイザー（幅1pxのドラッグ可能エリア）を追加
- マウスドラッグでパネル幅を自由に調整可能
- 最小幅240px、最大幅600pxに制限
- リサイズした幅をLocalStorageに保存

## 技術的な変更

### Backend
- **`backend/app/models/task.rb`**
  - `priority_order` scopeにlimitパラメータを追加（デフォルト5件）
  
- **`backend/app/controllers/api/tasks_controller.rb`**
  - `priority`アクションでクエリパラメータ`limit`を受け取る
  - 1-50の範囲にバリデーション

### Frontend
- **`frontend/src/features/priority/usePriorityTasks.ts`**
  - `usePriorityTasks`フックにlimitパラメータを追加
  - queryKeyにlimitを含めてキャッシュを適切に管理
  
- **`frontend/src/features/priority/PriorityTasksPanel.tsx`**
  - React hooksでLocalStorageと同期（`isCollapsed`、`limit`、`width`）
  - リサイズ処理でマウスイベントを監視（`useEffect`でクリーンアップ）
  - 折りたたみ時はコンテンツを非表示にしてDOMを軽量化

## UI/UXの改善

### Before
- パネルの幅が固定で画面を圧迫
- 表示件数が5件固定で調整不可
- 常に表示されてスペースを占有

### After
- パネル幅を自由に調整可能（240px〜600px）
- 表示件数を3/5/10/15件から選択可能
- 折りたたんで画面スペースを有効活用
- 設定が保存されて次回訪問時も適用される

## テスト計画
- [ ] 折りたたみボタンのクリックで正しく開閉するか
- [ ] LocalStorageに設定が保存されているか（ページリロード後も維持）
- [ ] 件数選択ドロップダウンで件数が変更されるか
- [ ] リサイザーをドラッグしてパネル幅が調整できるか
- [ ] 最小幅・最大幅の制限が機能しているか
- [ ] ダークモードで正しく表示されるか

## スクリーンショット
（実際の動作を確認してスクリーンショットを追加してください）

## 影響範囲
- 優先タスクパネルのUIのみ
- 既存のタスク管理機能に影響なし
- バックエンドAPIの互換性を維持（limitパラメータは任意）

🤖 Generated with [Claude Code](https://claude.com/claude-code)