### PR TITLE
refactor: alert()をToast通知に統一 (#189)

### DIFF
--- a/frontend/src/features/tasks/useCreateTask.ts
+++ b/frontend/src/features/tasks/useCreateTask.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "../../lib/apiClient";
 import type { Task, CreateTaskPayload, ISODateString } from "../../types";
 import { pushSiteHistory } from "../../lib/siteHistory";
+import { useToast } from "../../components/ToastProvider";
 
 export type CreateTaskInput = {
   title: string;
@@ -36,6 +37,7 @@ async function createTaskApi(input: CreateTaskInput): Promise<Task> {
 
 export function useCreateTask() {
   const qc = useQueryClient();
+  const { push } = useToast();
 
   return useMutation<Task, Error, CreateTaskInput, { prevTasks?: Task[]; tempId?: number }>({
     mutationKey: ["createTask"],
@@ -67,7 +69,7 @@ export function useCreateTask() {
 
     onError: (err, _vars, ctx) => {
       if (ctx?.prevTasks) qc.setQueryData(["tasks"], ctx.prevTasks);
-      alert(err instanceof Error ? err.message : "作成に失敗しました");
+      push(err instanceof Error ? err.message : "作成に失敗しました", "error");
     },
 
     onSuccess: (created, vars, ctx) => {

--- a/frontend/src/features/tasks/useDeleteTask.ts
+++ b/frontend/src/features/tasks/useDeleteTask.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "../../lib/apiClient";
 import type { Task } from "../../types/task";
+import { useToast } from "../../components/ToastProvider";
 
 async function deleteTaskApi(id: number): Promise<void> {
   await api.delete(`/tasks/${id}`);
@@ -8,6 +9,7 @@ async function deleteTaskApi(id: number): Promise<void> {
 
 export function useDeleteTask() {
   const qc = useQueryClient();
+  const { push } = useToast();
 
   return useMutation({
     mutationFn: deleteTaskApi,
@@ -20,11 +22,11 @@ export function useDeleteTask() {
 
       return { prevTasks };
     },
-    onError: (_err, _id, ctx) => {
+    onError: (err, _id, ctx) => {
       if (ctx?.prevTasks) {
         qc.setQueryData(["tasks"], ctx.prevTasks);
       }
-      alert("削除に失敗しました");
+      push(err instanceof Error ? err.message : "削除に失敗しました", "error");
     },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: ["tasks"] });

--- a/frontend/src/features/tasks/useUpdateTask.ts
+++ b/frontend/src/features/tasks/useUpdateTask.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import api from "../../lib/apiClient";
 import type { Task, UpdateTaskPayload } from "../../types";
 import { sortFlatForUI } from "../tasks/nest";
+import { useToast } from "../../components/ToastProvider";
 
 type UpdateInput = {
   id: number;
@@ -47,6 +48,7 @@ function normalize(data: UpdateInput["data"]) {
 
 export function useUpdateTask() {
   const qc = useQueryClient();
+  const { push } = useToast();
 
   return useMutation<
     Task,
@@ -112,14 +114,14 @@ export function useUpdateTask() {
       return { prevPriority, prevTasksEntries };
     },
 
-    onError: (_e, _v, ctx) => {
+    onError: (err, _v, ctx) => {
       if (ctx?.prevPriority) qc.setQueryData(["priorityTasks"], ctx.prevPriority);
       ctx?.prevTasksEntries?.forEach(([key, data]) => {
         if (Array.isArray(key)) {
           qc.setQueryData(key, data);
         }
       });
-      alert("更新に失敗しました");
+      push(err instanceof Error ? err.message : "更新に失敗しました", "error");
     },
 
     onSuccess: (fresh) => {


### PR DESCRIPTION
## 概要
タスク操作のエラーハンドリングで使用されている `alert()` を `ToastProvider` の Toast 通知に統一しました。

## 変更内容
- **useCreateTask.ts**: `alert()` → `useToast().push()` に変更
- **useUpdateTask.ts**: `alert()` → `useToast().push()` に変更
- **useDeleteTask.ts**: `alert()` → `useToast().push()` に変更
- エラーオブジェクトからメッセージを抽出して表示するように改善

## 修正前の問題点
1. ブラウザネイティブの `alert()` はモーダルで操作をブロックする
2. プロジェクトに `ToastProvider` が存在するのに活用されていない
3. 更新・削除時は元のエラーメッセージが表示されず、デバッグが困難

## メリット
- ✅ UI/UX の一貫性向上（非ブロッキングな通知）
- ✅ より詳細なエラー情報の提供
- ✅ プロジェクト全体の Toast 通知システムを活用
- ✅ 3秒後に自動で消えるため、ユーザー体験が向上

## テスト方法
1. タスク作成エラー: タイトルを空にして作成を試みる
2. タスク更新エラー: ネットワークを切断して更新を試みる
3. タスク削除エラー: ネットワークを切断して削除を試みる

各操作で画面右上に赤い Toast 通知が表示されることを確認してください。

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)