### PR TITLE
refactor: any型を削除して型安全性を向上 (#191)

### DIFF
--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -3,6 +3,7 @@ import axios, {
   AxiosHeaders,
   isCancel,
   type AxiosResponseHeaders,
+  type RawAxiosResponseHeaders,
 } from "axios";
 import type { InternalAxiosRequestConfig, AxiosResponse } from "axios";
 import { demoStore } from "./demoStore";
@@ -45,12 +46,12 @@ function getHeader(h: unknown, key: string): string | undefined {
 }
 
 /** 任意の Headers/AxiosResponseHeaders からトークン保存 */
-export function saveAuthFromHeaders(headers: AxiosResponseHeaders | Headers) {
+export function saveAuthFromHeaders(headers: AxiosResponseHeaders | RawAxiosResponseHeaders | Headers) {
   const getter =
     headers instanceof Headers
       ? (k: string) =>
           headers.get(k) ?? headers.get(k.toLowerCase()) ?? undefined
-      : (k: string) => getHeader(headers as any, k);
+      : (k: string) => getHeader(headers as AxiosResponseHeaders | RawAxiosResponseHeaders, k);
 
   const at = getter("access-token");
   const client = getter("client");
@@ -91,7 +92,7 @@ api.interceptors.request.use((config) => {
 
   headers.set("x-auth-start", String(Date.now()));
 
-  if (typeof FormData !== "undefined" && (config as any).data instanceof FormData) {
+  if (typeof FormData !== "undefined" && config.data instanceof FormData) {
     headers.delete("Content-Type");
   }
 
@@ -102,7 +103,7 @@ api.interceptors.request.use((config) => {
 /** ===== Response interceptor ===== */
 api.interceptors.response.use(
   (res) => {
-    if (!DEMO) saveAuthFromHeaders(res.headers as any);
+    if (!DEMO) saveAuthFromHeaders(res.headers as AxiosResponseHeaders | RawAxiosResponseHeaders);
     return res;
   },
   (error) => {


### PR DESCRIPTION
## 概要
AuthContext.tsxとapiClient.tsに存在するany型を適切な型定義に置き換え、型安全性を向上させました。

Close #191

## 変更内容

### AuthContext.tsx
- `navigator as any` を `ExtendedNavigator` インターフェースに置き換え
  - webdriverプロパティに対応した型定義を追加
- `error?.config as any` を `AxiosConfigWithRetry` インターフェースに置き換え
  - `_retry`プロパティを持つAxios設定の型を明示
- ヘッダー設定時に `AxiosHeaders.from()` を使用して型安全性を確保

### apiClient.ts
- `RawAxiosResponseHeaders` 型のインポートを追加
- `headers as any` を `AxiosResponseHeaders | RawAxiosResponseHeaders` に置き換え
- 不要な型アサーション `(config as any).data` を削除

## テスト計画
- [x] TypeScript型チェックが成功すること
- [x] プロダクションビルドが成功すること (922ms)
- [x] any型が完全に削除されていること
- [ ] 既存の機能が正常に動作すること（手動テスト）

## 影響範囲
- 認証周りの型安全性向上
- コンパイル時のエラー検出が可能に

🤖 Generated with [Claude Code](https://claude.com/claude-code)