### PR TITLE
feat: カレンダーページのルーティングとナビゲーションを追加

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -104,6 +104,14 @@ const Sidebar = () => {
                 タスク
               </NavLink>
               <NavLink
+                to="/calendar"
+                className={({ isActive }) =>
+                  isActive ? "font-semibold text-blue-700" : "hover:underline"
+                }
+              >
+                カレンダー
+              </NavLink>
+              <NavLink
                 to="/account"
                 className={({ isActive }) =>
                   isActive ? "font-semibold text-blue-700" : "hover:underline"

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -1,0 +1,11 @@
+// src/pages/CalendarPage.tsx
+export default function CalendarPage() {
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-bold mb-4">カレンダー</h1>
+      <p className="text-gray-600">
+        期限をカレンダー形式で表示する機能を実装予定です。
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -8,6 +8,7 @@ import RequireAuth from "../components/RequireAuth";
 import Account from "../pages/Account";
 import Help from "../pages/Help";
 import Home from "../pages/Home";
+import CalendarPage from "../pages/CalendarPage";
 
 export const AppRouter = () => {
   return (
@@ -24,6 +25,7 @@ export const AppRouter = () => {
         <Route element={<RequireAuth />}>
           <Route element={<Layout />}>
             <Route path="/tasks" element={<TaskList />} />
+            <Route path="/calendar" element={<CalendarPage />} />
             <Route path="/account" element={<Account />} />
             <Route path="/help" element={<Help />} />
             {/* 保護領域内のフォールバックは /tasks */}


### PR DESCRIPTION
## 概要
カレンダービュー機能の基礎実装として、空のカレンダーページとルーティングを追加しました。

## 変更内容
- **CalendarPage.tsx**: 空のカレンダーページコンポーネントを作成
- **AppRouter.tsx**: `/calendar` ルートを追加
- **Sidebar.tsx**: サイドバーに「カレンダー」リンクを追加（タスクとアカウントの間）

## 動作確認
- [ ] `/calendar` にアクセスすると「カレンダー」ページが表示される
- [ ] サイドバーの「カレンダー」リンクをクリックすると `/calendar` に遷移する
- [ ] アクティブ状態のスタイルが正しく適用される

## 次のステップ
1. FullCalendar.jsライブラリの導入
2. 期限ありタスクのカレンダー表示実装
3. 色分け表示の実装

## 関連Issue
カレンダービュー機能の第一歩として、最小限の実装を行いました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)