### PR TITLE
feat: カレンダーページのモバイル対応（基本レイアウト）

### DIFF
--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -149,7 +149,7 @@ export default function CalendarPage() {
   };
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col p-6">
+    <div className="flex h-[calc(100vh-4rem)] flex-col p-3 md:p-6">
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold">カレンダー</h1>
         <div className="flex gap-3 text-sm">
@@ -173,7 +173,7 @@ export default function CalendarPage() {
       </div>
 
       {/* フィルターとビュー切替 */}
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-2">
           <label htmlFor="site-filter" className="text-sm font-medium text-gray-700">
             現場:
@@ -219,10 +219,10 @@ export default function CalendarPage() {
         </div>
       </div>
 
-      <div className="flex flex-1 gap-4 overflow-hidden">
+      <div className="flex flex-1 flex-col gap-4 overflow-hidden md:flex-row">
         <div className={[
           "rounded border bg-white p-4",
-          selectedDate ? "w-2/3" : "w-full"
+          selectedDate ? "md:w-2/3" : "w-full"
         ].join(" ")}>
           <FullCalendar
             ref={calendarRef}
@@ -251,7 +251,7 @@ export default function CalendarPage() {
         </div>
 
         {selectedDate && (
-          <div className="flex w-1/3 flex-col rounded border bg-white p-4">
+          <div className="flex flex-col rounded border bg-white p-4 md:w-1/3">
             <h2 className="mb-3 flex items-center justify-between text-lg font-semibold">
               <span>
                 {selectedDate.toLocaleDateString("ja-JP", {


### PR DESCRIPTION
## 概要
カレンダーページをスマートフォンやタブレットで快適に使えるよう、レスポンシブ対応を実装しました。

Closes #200

## 変更内容

### 1. レスポンシブレイアウト（縦積み対応）
- カレンダーとタスク一覧のコンテナに `flex-col md:flex-row` を適用
- **小画面（<768px）**: カレンダー → タスク一覧の縦積み表示
- **中画面以上（≥768px）**: 横並び表示（従来通り）
- カレンダーの幅クラスを `w-2/3` → `md:w-2/3` に変更
- タスク一覧の幅クラスを `w-1/3` → `md:w-1/3` に変更

### 2. パディング・余白の調整
- 最外コンテナのパディングを `p-6` → `p-3 md:p-6` に変更
- **小画面**: 12px（画面を有効活用）
- **中画面以上**: 24px（従来通り）

### 3. フィルター・ボタン配置の調整
- フィルターとビュー切替ボタンのコンテナに `flex-col gap-3 md:flex-row` を適用
- **小画面**: 縦積み配置（レイアウト崩れ防止）
- **中画面以上**: 横並び配置（従来通り）
- `md:items-center md:justify-between` で中画面以上の配置を維持

## 技術的な実装
- Tailwind CSSのレスポンシブユーティリティクラスを使用
- ブレークポイント: `md` (768px以上)
- モバイルファーストアプローチで実装
- デスクトップでの表示は完全に維持

## 変更されたファイル
- `frontend/src/pages/CalendarPage.tsx`: レスポンシブクラスの追加

## 動作確認
- [x] 小画面（<768px）でカレンダーとタスクが縦積みで表示される
- [x] 中画面以上（≥768px）で従来の横並びレイアウトが維持される
- [x] フィルターとボタンが小画面で縦積み、中画面以上で横並びになる
- [x] パディングが画面サイズに応じて調整される
- [x] すべての既存機能（ドラッグ&ドロップ、タスククリックなど）が正常動作

## スクリーンショット

### 小画面（モバイル）
カレンダーとタスク一覧が縦に並び、画面全体を有効活用できます。

### 中画面以上（デスクトップ）
従来通りの横並びレイアウトが維持されます。

## 期待される効果
- スマートフォンでカレンダーページが快適に使用可能
- タブレットでの表示品質向上
- デスクトップでは従来通りの表示を完全維持
- レスポンシブデザインの基盤確立

## 今後の拡張予定
この PR では最小限の必須対応を実装しました。以下は今後の改善候補です：
- 凡例の2列表示（小画面）
- フォントサイズの調整
- タッチ領域の拡大
- タッチデバイスでのドラッグ&ドロップ最適化

🤖 Generated with [Claude Code](https://claude.com/claude-code)