### PR TITLE
feat: 優先タスクパネルのモバイル対応（表示切替ボタン追加）

### DIFF
--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -35,6 +35,26 @@ const TaskList: PageComponent = () => {
     };
   }, []);
 
+  // 優先パネルの表示状態（小画面用）
+  const [showPriorityPanel, setShowPriorityPanel] = useState(() => {
+    try {
+      const saved = localStorage.getItem("priority-panel-visible");
+      return saved ? JSON.parse(saved) : false; // 小画面デフォルト非表示
+    } catch {
+      return false;
+    }
+  });
+
+  const togglePriorityPanel = () => {
+    setShowPriorityPanel((prev: boolean) => {
+      const next = !prev;
+      try {
+        localStorage.setItem("priority-panel-visible", JSON.stringify(next));
+      } catch {}
+      return next;
+    });
+  };
+
   const [sp] = useSearchParams();
   const rawFilters = parseTaskFilters(sp);
   const filters = useDebouncedValue(rawFilters, 300);
@@ -74,7 +94,18 @@ const TaskList: PageComponent = () => {
           </div>
         )}
 
-        <TaskFilterBar summary={`全 ${tasksFlat.length} 件・${orderLabel}/${dirLabel}`} />
+        <div className="flex items-center justify-between mb-4">
+          <TaskFilterBar summary={`全 ${tasksFlat.length} 件・${orderLabel}/${dirLabel}`} />
+
+          {/* 優先パネル表示切替ボタン（小画面のみ） */}
+          <button
+            onClick={togglePriorityPanel}
+            className="lg:hidden rounded bg-blue-600 px-3 py-1.5 text-sm text-white hover:bg-blue-700 transition-colors"
+            aria-label={showPriorityPanel ? "優先タスクを非表示" : "優先タスクを表示"}
+          >
+            {showPriorityPanel ? "優先タスクを隠す" : "優先タスク"}
+          </button>
+        </div>
 
         {filters.progress_min != null &&
           filters.progress_max != null &&
@@ -89,7 +120,11 @@ const TaskList: PageComponent = () => {
             <NewParentTaskForm />
             <InlineTaskTree tree={tasks} />
           </section>
-          <aside className="priority-panel self-start lg:sticky lg:top-20 border-l pl-4 z-0">
+          <aside className={[
+            "priority-panel self-start border-l pl-4 z-0",
+            "lg:block lg:sticky lg:top-20", // 大画面は常に表示＆sticky
+            showPriorityPanel ? "block" : "hidden" // 小画面は状態で切り替え
+          ].join(" ")}>
             <PriorityTasksPanel />
           </aside>
         </div>


### PR DESCRIPTION
## Summary
- 小画面では優先タスクパネルをデフォルト非表示に変更
- 「優先タスク」ボタンで表示/非表示を切り替え可能
- 表示状態はlocalStorageに保存され、リロード後も維持される
- 大画面では従来通り常に表示＆sticky配置

## Test plan
- [ ] 小画面（lg未満）で優先タスクパネルが初期状態で非表示になることを確認
- [ ] 「優先タスク」ボタンをクリックしてパネルが表示されることを確認
- [ ] もう一度ボタンをクリックして非表示になることを確認
- [ ] 表示状態でリロードして、表示状態が維持されることを確認
- [ ] 大画面（lg以上）で優先タスクパネルが常に表示されることを確認
- [ ] 大画面では切替ボタンが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)