### PR TITLE
feat: TaskFilterBarのモバイル対応を実装

### DIFF
--- a/frontend/src/features/tasks/TaskFilterBar.tsx
+++ b/frontend/src/features/tasks/TaskFilterBar.tsx
@@ -75,10 +75,10 @@ export function TaskFilterBar({ summary }: Props) {
   return (
     <section className="mb-4" data-testid="filter-bar">
       {/* 見出し＋絞り込み状況／件数表示／全解除 */}
-      <div className="mb-2 flex items-center justify-between gap-2">
+      <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0 flex items-center gap-2 flex-wrap">
           <h2 className="text-sm font-medium text-gray-700 shrink-0">フィルター &amp; 並び替え</h2>
-          <span aria-hidden className="h-4 w-px bg-gray-300/70 mx-1" />
+          <span aria-hidden className="hidden sm:inline h-4 w-px bg-gray-300/70 mx-1" />
           <span className="text-xs text-gray-500 shrink-0">絞り込み：</span>
           <div className="min-w-0 flex items-center gap-1 flex-wrap">
             {filterChips.length ? filterChips : <span className="text-xs text-gray-400">なし</span>}
@@ -124,7 +124,7 @@ export function TaskFilterBar({ summary }: Props) {
                     type="button"
                     aria-pressed={active}
                     onClick={() => toggleStatus(s)}
-                    className={["px-3 py-1 text-xs rounded-full transition", active ? "bg-white shadow border" : "text-gray-600 hover:bg-white/70"].join(" ")}
+                    className={["px-2 sm:px-3 py-1 text-[11px] sm:text-xs rounded-full transition", active ? "bg-white shadow border" : "text-gray-600 hover:bg-white/70"].join(" ")}
                   >
                     {label}
                   </button>
@@ -134,12 +134,14 @@ export function TaskFilterBar({ summary }: Props) {
           </div>
 
           {/* 3) 進捗（2） */}
-          <div className="sm:col-span-2 flex items-center justify-start text-xs text-gray-600">
-            <label className="flex items-center gap-2">
-              <span>進捗</span>
-              <input type="number" min={0} max={100} step={1} data-testid="progress-min" className="w-16 rounded border px-2 py-1" value={progress_min} onChange={onChangeProgress("progress_min")} placeholder="min" />
-              <span>–</span>
-              <input type="number" min={0} max={100} step={1} data-testid="progress-max" className="w-16 rounded border px-2 py-1" value={progress_max} onChange={onChangeProgress("progress_max")} placeholder="max" />
+          <div className="sm:col-span-2 text-xs text-gray-600">
+            <label className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <span className="shrink-0">進捗</span>
+              <div className="flex items-center gap-2">
+                <input type="number" min={0} max={100} step={1} data-testid="progress-min" className="w-full sm:w-16 rounded border px-2 py-1" value={progress_min} onChange={onChangeProgress("progress_min")} placeholder="min" />
+                <span className="shrink-0">–</span>
+                <input type="number" min={0} max={100} step={1} data-testid="progress-max" className="w-full sm:w-16 rounded border px-2 py-1" value={progress_max} onChange={onChangeProgress("progress_max")} placeholder="max" />
+              </div>
             </label>
           </div>
 


### PR DESCRIPTION
## Summary
- 小画面でヘッダー部分を縦積みレイアウトに変更
- ステータスボタンのフォントサイズとパディングを小画面で縮小（text-[11px]、px-2）
- 進捗入力欄を縦積みレイアウトに変更し、小画面では入力欄がフル幅に
- 区切り線を小画面では非表示に

## Test plan
- [ ] 小画面（sm未満）でヘッダーが縦積みになることを確認
- [ ] 小画面でステータスボタンが適切なサイズで表示されることを確認
- [ ] 小画面で進捗入力欄が縦積みで、入力欄がフル幅になることを確認
- [ ] 中画面以上（sm以上）で従来通りの横並びレイアウトになることを確認
- [ ] 大画面で表示が崩れていないことを確認
- [ ] すべてのフィルター機能が正しく動作することを確認

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)