### PR TITLE
feat: TaskImagePanelのモバイル対応を実装 (#212)

### DIFF
--- a/frontend/src/features/tasks/image/TaskImagePanel.tsx
+++ b/frontend/src/features/tasks/image/TaskImagePanel.tsx
@@ -127,9 +127,9 @@ export default function TaskImagePanel({ taskId }: Props) {
       className="mt-2 rounded-md border p-3 bg-white"
       data-testid={`image-panel-${taskId}`}
     >
-      <div className="mb-2 flex items-center justify-between gap-2">
+      <div className="mb-2 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <h3 className="text-sm font-medium">画像</h3>
-        <div className="space-x-2">
+        <div className="flex flex-col gap-2 sm:flex-row sm:space-x-2">
           <button
             data-testid="btn-pick"
             type="button"
@@ -171,11 +171,11 @@ export default function TaskImagePanel({ taskId }: Props) {
       {loading ? (
         <div className="text-xs text-gray-500">読み込み中…</div>
       ) : hasImage ? (
-        <div className="flex items-start gap-3">
+        <div className="flex flex-col items-start gap-3 sm:flex-row">
           <img
             src={data.image_thumb_url || data.image_url!}
             alt="サムネイル"
-            className="h-24 w-24 rounded object-cover ring-1 ring-gray-200"
+            className="h-32 w-32 rounded object-cover ring-1 ring-gray-200 sm:h-24 sm:w-24"
           />
           <a
             href={data.image_url!}


### PR DESCRIPTION
## 概要
TaskImagePanelコンポーネントをモバイル環境に最適化しました。

## 変更内容

### レスポンシブ対応の詳細

1. **ヘッダー部分のレイアウト**
   - 変更前: `flex items-center justify-between` で横並び固定
   - 変更後: `flex flex-col sm:flex-row` でモバイルは縦並び、640px以上で横並び

2. **ボタングループ**
   - 変更前: `space-x-2` で横並び固定
   - 変更後: `flex flex-col gap-2 sm:flex-row sm:space-x-2` でモバイルは縦並び
   - 「画像を追加/変更」「削除」ボタンがモバイルで縦に並び操作しやすく

3. **画像プレビュー部分**
   - 変更前: `flex items-start` で横並び固定
   - 変更後: `flex flex-col sm:flex-row` でモバイルは縦並び

4. **サムネイルサイズ**
   - 変更前: `h-24 w-24` で固定
   - 変更後: `h-32 w-32 sm:h-24 sm:w-24` でモバイルは大きめ表示
   - モバイルでより見やすいサイズに調整

## モバイルでの改善点
- ボタンが縦並びになり、タップしやすく
- サムネイルが大きくなり、画像の確認がしやすく
- 「元画像を開く」リンクも見やすい位置に配置

## テスト
- [x] ビルド成功を確認
- [x] レスポンシブクラスが正しく適用されていることを確認

## 関連イシュー
Closes #212

## 関連PR
他のモバイル対応PR:
- #211 TaskDrawer
- #209 TaskFilterBar
- #207 優先タスクパネル
- #204 #205 タスクリスト
- #202 #203 サイドバー
- #200 #201 カレンダーページ

🤖 Generated with [Claude Code](https://claude.com/claude-code)