### PR TITLE
feat: ダークモード手動切り替え機能を実装

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 import useAuth from "../providers/useAuth";
 import { useSidebar } from "../contexts/SidebarContext";
+import { useDarkMode } from "../hooks/useDarkMode";
 
 const HEADER_H = "h-14";
 
@@ -15,6 +16,7 @@ export default function Header({ showDemoBadge = true }: HeaderProps) {
   const qc = useQueryClient();
   const { authed, uid, name, signOut } = useAuth();
   const { toggle } = useSidebar();
+  const { isDark, toggle: toggleDark } = useDarkMode();
 
   const handleLogout = async () => {
     qc.clear();
@@ -70,6 +72,27 @@ export default function Header({ showDemoBadge = true }: HeaderProps) {
               デモモード
             </span>
           )}
+
+          {/* ダークモード切り替えボタン */}
+          <button
+            type="button"
+            onClick={toggleDark}
+            className="p-2 hover:bg-white/10 rounded transition-colors"
+            aria-label={isDark ? "ライトモードに切り替え" : "ダークモードに切り替え"}
+            title={isDark ? "ライトモードに切り替え" : "ダークモードに切り替え"}
+          >
+            {isDark ? (
+              // 太陽アイコン（ライトモード）
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+              </svg>
+            ) : (
+              // 月アイコン（ダークモード）
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+              </svg>
+            )}
+          </button>
 
           {authed ? (
             <>

--- a/frontend/src/hooks/useDarkMode.ts
+++ b/frontend/src/hooks/useDarkMode.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+export function useDarkMode() {
+  // 初期状態: デフォルトでダークモード有効
+  const [isDark, setIsDark] = useState(() => {
+    try {
+      const stored = localStorage.getItem("darkMode");
+      return stored !== null ? stored === "true" : true; // デフォルトでtrue
+    } catch {
+      return true;
+    }
+  });
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (isDark) {
+      root.classList.add("dark");
+    } else {
+      root.classList.remove("dark");
+    }
+
+    try {
+      localStorage.setItem("darkMode", String(isDark));
+    } catch {
+      // ignore
+    }
+  }, [isDark]);
+
+  const toggle = () => setIsDark((prev) => !prev);
+
+  return { isDark, toggle };
+}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
-  darkMode: 'media', // OSの設定に追従
+  darkMode: 'class', // HTMLのclassで制御
   theme: { extend: {} },
   plugins: [],
 };


### PR DESCRIPTION
## 概要
ユーザーが手動でダークモード/ライトモードを切り替えられる機能を実装しました。

## 変更内容

### 1. Tailwind CSS設定の変更
- `darkMode`設定を`'media'`（OS設定に自動追従）から`'class'`（手動制御）に変更
- これにより、`<html>`要素の`class`属性で制御可能に

### 2. useDarkModeカスタムフックの実装
- **ファイル**: `frontend/src/hooks/useDarkMode.ts`
- **機能**:
  - localStorageを使用してダークモード設定を永続化
  - デフォルトでダークモードを有効化（初回アクセス時）
  - `document.documentElement`に`dark`クラスを追加/削除
  - `toggle`関数でモードを切り替え

### 3. Headerコンポーネントの拡張
- **ファイル**: `frontend/src/components/Header.tsx`
- **機能**:
  - ダークモード切り替えボタンを追加
  - ダークモード時: 太陽アイコン（ライトモードへ切り替え）
  - ライトモード時: 月アイコン（ダークモードへ切り替え）
  - `useDarkMode`フックを統合

## 動作確認
- ✅ デフォルトでダークモードが適用される
- ✅ ヘッダーの切り替えボタンでライト/ダークモードを切り替えられる
- ✅ ページリロード後も設定が保持される
- ✅ すべてのコンポーネントでダークモードスタイルが正しく適用される

## スクリーンショット
（必要に応じて追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)