### PR TITLE
feat: カレンダーページのダークモード対応を実装

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -43,15 +43,122 @@ body.is-dragging [data-testid^="task-item-"] {
   -webkit-user-select: none;
 }
 
-/* カレンダーの土日祝日の背景色 */
-.fc-day-sunday {
-  background-color: #fef2f2 !important; /* 薄い赤 */
+/* カレンダーの土日祝日の日付色（背景色は削除） */
+.fc-day-sunday .fc-daygrid-day-number {
+  color: #dc2626 !important; /* 赤色 */
 }
 
-.fc-day-saturday {
-  background-color: #eff6ff !important; /* 薄い青 */
+.fc-day-saturday .fc-daygrid-day-number {
+  color: #2563eb !important; /* 青色 */
 }
 
-.fc-day-holiday {
-  background-color: #fef2f2 !important; /* 薄い赤（祝日） */
+.fc-day-holiday .fc-daygrid-day-number {
+  color: #dc2626 !important; /* 赤色（祝日） */
+}
+
+/* ダークモード時のカレンダー背景とテキスト */
+.dark .fc {
+  --fc-border-color: #374151;
+  --fc-page-bg-color: #1f2937;
+  --fc-neutral-bg-color: #1f2937;
+  --fc-neutral-text-color: #f3f4f6;
+  --fc-event-text-color: #ffffff;
+}
+
+/* カレンダーのタイトル（年月）を見やすく */
+.fc-toolbar-title {
+  color: #111827 !important;
+  font-weight: 600 !important;
+}
+
+.dark .fc-toolbar-title {
+  color: #f3f4f6 !important;
+  font-weight: 600 !important;
+}
+
+/* カレンダーのイベント（タスク）の文字色を白に */
+.fc-event-title {
+  color: #ffffff !important;
+}
+
+.dark .fc-event-title {
+  color: #ffffff !important;
+}
+
+.dark .fc-theme-standard td,
+.dark .fc-theme-standard th {
+  border-color: #374151;
+}
+
+.dark .fc-col-header-cell {
+  background-color: #1f2937;
+  color: #f3f4f6;
+}
+
+.dark .fc-daygrid-day-number {
+  color: #f3f4f6;
+}
+
+.dark .fc .fc-button {
+  background-color: #374151;
+  border-color: #4b5563;
+  color: #f3f4f6;
+}
+
+.dark .fc .fc-button:hover {
+  background-color: #4b5563;
+}
+
+.dark .fc .fc-button-primary:not(:disabled):active,
+.dark .fc .fc-button-primary:not(:disabled).fc-button-active {
+  background-color: #2563eb;
+  border-color: #2563eb;
+}
+
+.dark .fc-daygrid-day {
+  background-color: #1f2937;
+}
+
+.dark .fc-day-today {
+  background-color: #1e3a5f !important;
+}
+
+/* 時間軸の表示を見やすく */
+.dark .fc-timegrid-slot-label {
+  color: #f3f4f6;
+}
+
+.dark .fc-timegrid-axis {
+  color: #f3f4f6;
+}
+
+.fc-timegrid-slot-label {
+  font-size: 0.875rem;
+}
+
+/* 週表示のイベント（タスク）の文字色 */
+.dark .fc-timegrid-event {
+  color: #ffffff !important;
+}
+
+.fc-timegrid-event .fc-event-title {
+  color: #ffffff !important;
+  font-weight: 500 !important;
+}
+
+.fc-timegrid-event .fc-event-time {
+  color: #ffffff !important;
+  font-weight: 600 !important;
+  font-size: 0.75rem !important;
+}
+
+/* 月表示のイベント時間も見やすく */
+.fc-daygrid-event .fc-event-time {
+  color: #ffffff !important;
+  font-weight: 600 !important;
+}
+
+/* 日付の「日」を非表示 */
+.fc-daygrid-day-number::after {
+  content: none !important;
 }

--- a/frontend/src/pages/CalendarPage.tsx
+++ b/frontend/src/pages/CalendarPage.tsx
@@ -149,10 +149,10 @@ export default function CalendarPage() {
   };
 
   return (
-    <div className="flex h-[calc(100vh-4rem)] flex-col p-3 md:p-6">
+    <div className="flex h-[calc(100vh-4rem)] flex-col p-3 md:p-6 bg-gray-50 dark:bg-gray-900">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">カレンダー</h1>
-        <div className="flex gap-3 text-sm">
+        <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">カレンダー</h1>
+        <div className="flex gap-3 text-sm text-gray-700 dark:text-gray-300">
           <div className="flex items-center gap-1">
             <div className="h-3 w-3 rounded" style={{ backgroundColor: "#ef4444" }}></div>
             <span>期限切れ</span>
@@ -175,12 +175,12 @@ export default function CalendarPage() {
       {/* フィルターとビュー切替 */}
       <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-2">
-          <label htmlFor="site-filter" className="text-sm font-medium text-gray-700">
+          <label htmlFor="site-filter" className="text-sm font-medium text-gray-700 dark:text-gray-300">
             現場:
           </label>
           <select
             id="site-filter"
-            className="rounded border border-gray-300 bg-white px-3 py-1.5 text-sm"
+            className="rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 px-3 py-1.5 text-sm"
             value={selectedSite}
             onChange={(e) => setSelectedSite(e.target.value)}
           >
@@ -199,7 +199,7 @@ export default function CalendarPage() {
               "rounded px-3 py-1.5 text-sm font-medium transition-colors",
               calendarView === "month"
                 ? "bg-blue-600 text-white"
-                : "bg-gray-200 text-gray-700 hover:bg-gray-300",
+                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600",
             ].join(" ")}
             onClick={() => setCalendarView("month")}
           >
@@ -210,7 +210,7 @@ export default function CalendarPage() {
               "rounded px-3 py-1.5 text-sm font-medium transition-colors",
               calendarView === "week"
                 ? "bg-blue-600 text-white"
-                : "bg-gray-200 text-gray-700 hover:bg-gray-300",
+                : "bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600",
             ].join(" ")}
             onClick={() => setCalendarView("week")}
           >
@@ -221,7 +221,7 @@ export default function CalendarPage() {
 
       <div className="flex flex-1 flex-col gap-4 overflow-hidden md:flex-row">
         <div className={[
-          "rounded border bg-white p-4",
+          "rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4",
           selectedDate ? "md:w-2/3" : "w-full"
         ].join(" ")}>
           <FullCalendar
@@ -247,52 +247,53 @@ export default function CalendarPage() {
             slotMaxTime="22:00:00"
             allDaySlot={true}
             dayCellClassNames={dayCellClassNames}
+            dayCellContent={(arg) => arg.dayNumberText.replace('日', '')}
           />
         </div>
 
         {selectedDate && (
-          <div className="flex flex-col rounded border bg-white p-4 md:w-1/3">
-            <h2 className="mb-3 flex items-center justify-between text-lg font-semibold">
+          <div className="flex flex-col rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 md:w-1/3">
+            <h2 className="mb-3 flex items-center justify-between text-lg font-semibold text-gray-900 dark:text-gray-100">
               <span>
                 {selectedDate.toLocaleDateString("ja-JP", {
                   month: "long",
                   day: "numeric",
                 })}
               </span>
-              <span className="text-sm font-normal text-gray-600">
+              <span className="text-sm font-normal text-gray-600 dark:text-gray-400">
                 {tasksOnSelectedDate.length}件
               </span>
             </h2>
             <div className="flex-1 overflow-y-auto">
               {tasksOnSelectedDate.length === 0 ? (
-                <p className="text-gray-500">この日のタスクはありません</p>
+                <p className="text-gray-500 dark:text-gray-400">この日のタスクはありません</p>
               ) : (
                 <div className="space-y-2">
                   {tasksOnSelectedDate.map((task) => (
                     <div
                       key={task.id}
                       className={[
-                        "cursor-pointer rounded border p-3 transition-colors hover:bg-gray-50",
+                        "cursor-pointer rounded border border-gray-200 dark:border-gray-700 p-3 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700",
                         selectedTaskId === task.id ? "ring-2 ring-blue-500" : "",
                       ].join(" ")}
                       onClick={() => setSelectedTaskId(task.id)}
                     >
                       <div className="flex items-start justify-between">
                         <div className="flex-1">
-                          <h3 className="font-medium">{task.title}</h3>
+                          <h3 className="font-medium text-gray-900 dark:text-gray-100">{task.title}</h3>
                           {task.site && (
-                            <p className="text-sm text-gray-600">現場: {task.site}</p>
+                            <p className="text-sm text-gray-600 dark:text-gray-400">現場: {task.site}</p>
                           )}
                           <div className="mt-1 flex items-center gap-3 text-sm">
-                            <span className="text-gray-600">進捗: {task.progress}%</span>
+                            <span className="text-gray-600 dark:text-gray-400">進捗: {task.progress}%</span>
                             <span
                               className={[
                                 "rounded px-2 py-0.5 text-xs",
                                 task.status === "completed"
-                                  ? "bg-green-100 text-green-800"
+                                  ? "bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300"
                                   : task.status === "in_progress"
-                                    ? "bg-blue-100 text-blue-800"
-                                    : "bg-gray-100 text-gray-800",
+                                    ? "bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-300"
+                                    : "bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300",
                               ].join(" ")}
                             >
                               {task.status === "completed"


### PR DESCRIPTION
## 概要
カレンダーページを完全にダークモード対応しました。視認性を大幅に改善し、土日祝日の表示方法も最適化しました。

## 変更内容

### 📅 カレンダーコンポーネント
- **タイトル（年月）**: ライト/ダークモードで明確に表示
- **日付数字**: ダークモードで白色、明瞭な表示
- **土日祝日**: 日付の数字のみ色付き（背景色を削除してすっきり）
  - 日曜日・祝日: 赤色 (`#dc2626`)
  - 土曜日: 青色 (`#2563eb`)
- **今日の日付**: ダークモード用の青系背景 (`#1e3a5f`)
- **日付表示**: 「1日」→「1」のように「日」の文字を削除

### 📋 タスク表示
- **イベントタイトル**: 白色 + やや太字で視認性向上
- **時間表示**: 白色 + 太字 + やや大きめのフォントで明確に
- **月表示**: イベント時間を太字で見やすく
- **週表示**: 時間軸とタスクの視認性を大幅改善

### 🎨 UI要素
- **ページ背景**: `bg-gray-50 dark:bg-gray-900`
- **カレンダー背景**: `bg-white dark:bg-gray-800`
- **ボーダー**: `border-gray-200 dark:border-gray-700`
- **現場フィルター**: セレクトボックスのダークモード対応
- **月/週切替ボタン**: ダークモード用のスタイル

### 📊 サイドパネル
- **タスク一覧**: 背景・ボーダー・テキスト色のダークモード対応
- **タスクカード**: ホバー時の背景色 (`dark:hover:bg-gray-700`)
- **ステータスバッジ**: 
  - 完了: `bg-green-100 dark:bg-green-900/50`
  - 進行中: `bg-blue-100 dark:bg-blue-900/50`
  - 未着手: `bg-gray-100 dark:bg-gray-700`

## 技術的詳細

### CSS変更（index.css）
- FullCalendarのダークモード用CSSカスタム変数を設定
- 土日祝日は背景色ではなく日付数字の色で区別
- 時間軸、ボタン、セルの色をダークモード対応

### コンポーネント変更（CalendarPage.tsx）
- すべてのTailwind classにダークモードバリアントを追加
- `dayCellContent` で日付から「日」を削除

## スクリーンショット
ダークモード時のカレンダー表示が大幅に改善され、すべてのテキストとUI要素が明確に見えるようになりました。

## テスト
- [x] ライトモードでの表示確認
- [x] ダークモードでの表示確認
- [x] 月表示での視認性確認
- [x] 週表示での視認性確認
- [x] 土日祝日の色表示確認
- [x] タスクのドラッグ&ドロップ動作確認
- [x] フィルター・ボタンの動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)