### PR TITLE
feat: タスク編集のUX改善 - インライン編集機能の実装

### DIFF
--- a/frontend/src/features/tasks/inline/InlineTaskRow.tsx
+++ b/frontend/src/features/tasks/inline/InlineTaskRow.tsx
@@ -111,17 +111,15 @@ export default function InlineTaskRow({ task, depth, prevId = null }: RowProps) 
     });
   };
 
-  // === ドロワー開閉 ===
+  // === インライン編集（全タスク対応） ===
   const handleTitleClick = () => {
-    if (isParent) openDrawer(task.id, titleRef.current || undefined);
-    else setEditing(true);
+    setEditing(true);
   };
 
   const handleTitleKeyDown = (e: React.KeyboardEvent) => {
-    if (!isParent) return;
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      openDrawer(task.id, titleRef.current || undefined);
+      setEditing(true);
     }
   };
 

--- a/frontend/src/features/tasks/inline/TaskRowDisplay.tsx
+++ b/frontend/src/features/tasks/inline/TaskRowDisplay.tsx
@@ -43,16 +43,14 @@ export function TaskRowDisplay({ task, isParent, titleRef, onTitleClick, onTitle
         <span
           ref={titleRef}
           data-testid={`task-title-${task.id}`}
-          role={isParent ? "button" : undefined}
-          tabIndex={isParent ? 0 : undefined}
-          aria-haspopup={isParent ? "dialog" : undefined}
-          title={isParent ? "詳細を開く" : undefined}
+          role="button"
+          tabIndex={0}
+          title="クリックして編集"
           className={[
-            "truncate hover:underline decoration-dotted",
+            "truncate hover:underline decoration-dotted cursor-pointer",
             isParent
               ? "text-[18px] md:text-[20px] font-semibold leading-tight"
               : "text-[15px] font-medium",
-            isParent ? "cursor-pointer" : "cursor-text",
             task.status === "completed" ? "text-gray-400 dark:text-gray-500 line-through" : "text-gray-900 dark:text-gray-100",
           ].join(" ")}
         >


### PR DESCRIPTION
## 概要

Issue #220 の対応として、タスク編集のUX改善（インライン編集機能）を実装しました。

## 変更内容

### 現状の課題
- 編集にモーダルやドロワーを開く必要があり、操作手順が多い
- 親タスクと子タスクで編集方法が異なる（親: ドロワー、子: インライン）
- ユーザーがタスクを素早く編集できない

### 改善内容
✅ 全タスク（親・子）でクリックによるインライン編集を実装
✅ タイトルクリックで即座に編集モードに移行
✅ Enterキーまたはスペースキーでも編集モード開始可能
✅ 統一されたUX体験の提供

## 実装詳細

### 変更ファイル

#### `InlineTaskRow.tsx`
- `handleTitleClick`: 親タスクのドロワー表示をインライン編集に変更
- `handleTitleKeyDown`: 全タスクでキーボード操作による編集開始をサポート

#### `TaskRowDisplay.tsx`
- タイトル要素を全タスクでクリック可能に変更
- `cursor-pointer`クラスを全タスクに適用
- `title`属性を「クリックして編集」に統一

## 期待される効果

- ✨ 編集操作の手間が大幅に削減（2-3ステップ → 1ステップ）
- 🎯 親タスク・子タスクで統一されたUX
- ⚡ 作業効率の向上とユーザー体験の改善

## テスト

- [x] 親タスクのタイトルクリックでインライン編集が開始される
- [x] 子タスクのタイトルクリックでインライン編集が開始される
- [x] キーボード操作（Enter/Space）で編集モードに入れる
- [x] HMRが正常に動作する

## 関連Issue

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)