### PR TITLE
UpdateTaskPayloadにsiteフィールドを追加

### DIFF
--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -16,7 +16,7 @@ export type CreateTaskPayload = {
 
 /** タスク更新時のペイロード */
 export type UpdateTaskPayload = {
-  task: Partial<Pick<Task, "status" | "progress" | "title" | "deadline" | "description">>;
+  task: Partial<Pick<Task, "status" | "progress" | "title" | "deadline" | "description" | "site">>;
 };
 
 /** ユーザー情報レスポンス */


### PR DESCRIPTION
## 概要

タスクの現場名編集がAPIに送信されない問題を修正しました。

Fixes #226

## 問題

現在、`UpdateTaskPayload` 型に `site` フィールドが含まれていないため、タスクの現場名を編集してもAPIに送信されず、更新が保存されていませんでした。

### 症状
1. Workflowyスタイルで親タスクの現場名を編集
2. Enter または フォーカスを外す
3. 現場名が更新されない（APIに送信されていない）

## 解決策

`UpdateTaskPayload` 型に `site` フィールドを追加しました。

### 修正内容

#### `frontend/src/types/api.ts:19`

```diff
export type UpdateTaskPayload = {
-  task: Partial<Pick<Task, "status" | "progress" | "title" | "deadline" | "description">>;
+  task: Partial<Pick<Task, "status" | "progress" | "title" | "deadline" | "description" | "site">>;
};
```

## 影響範囲

- `frontend/src/types/api.ts` - 型定義の修正のみ（1行）
- `frontend/src/features/tasks/useUpdateTask.ts` - 変更不要（すでに `site` 対応済み）
- `frontend/src/features/tasks/workflowy/WorkflowyTaskRow.tsx` - 変更不要（すでに現場名編集実装済み）

## テスト

手動テスト:
- [x] TypeScriptコンパイルエラーなし
- [x] 親タスクの現場名を編集 → 保存される
- [x] 既存の更新処理（title, status, progress等）に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)