### PR TITLE
ドラッグ&ドロップ時の視覚的フィードバックを追加

### DIFF
--- a/frontend/src/features/tasks/workflowy/WorkflowyTaskRow.tsx
+++ b/frontend/src/features/tasks/workflowy/WorkflowyTaskRow.tsx
@@ -42,6 +42,7 @@ export default function WorkflowyTaskRow({
   const [editTitle, setEditTitle] = useState(task.title);
   const [editSite, setEditSite] = useState(task.site || "");
   const [dragging, setDragging] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
   const [creatingChild, setCreatingChild] = useState(false);
   const [childTitle, setChildTitle] = useState("");
 
@@ -200,12 +201,18 @@ export default function WorkflowyTaskRow({
     if (!isParent) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = "move";
+    setDragOver(true);
+  };
+
+  const handleDragLeave = () => {
+    setDragOver(false);
   };
 
   const handleDropLocal = (e: DragEvent) => {
     if (!isParent) return;
     e.preventDefault();
     e.stopPropagation();
+    setDragOver(false);
     onDrop?.(task.id, prevId);
   };
 
@@ -224,6 +231,7 @@ export default function WorkflowyTaskRow({
           "relative group flex items-center gap-2 py-1 px-2 hover:bg-white/5 transition-colors",
           "min-h-[26px]", // 24-28px
           dragging ? "opacity-50" : "",
+          dragOver ? "before:absolute before:top-0 before:left-0 before:right-0 before:h-0.5 before:bg-sky-400 before:shadow-lg before:shadow-sky-400/50" : "",
         ].join(" ")}
         style={{
           paddingLeft: `${indentPx + 8}px`,
@@ -233,6 +241,7 @@ export default function WorkflowyTaskRow({
         onDragStart={handleDragStart}
         onDragEnd={handleDragEndLocal}
         onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
         onDrop={handleDropLocal}
       >
         {/* 折りたたみアイコン */}


### PR DESCRIPTION
## 概要

親タスクをドラッグ&ドロップで並び替える際、ドロップ先の位置に**青いライン**を表示するようになりました。

Fixes #228

## 問題

現在、タスクをドラッグ&ドロップする際、どこにドロップされるかが視覚的に分かりにくい状態でした。

## 解決策

ドラッグオーバー時に、ドロップ先のタスクの**上部に青いライン**を表示します。これはWorkflowy、Notion、Trelloなどで採用されている標準的なUXパターンです。

## 実装内容

### `WorkflowyTaskRow.tsx`

#### state追加
```typescript
const [dragOver, setDragOver] = useState(false);
```

#### イベントハンドラー
```typescript
const handleDragOver = (e: DragEvent) => {
  if (!isParent) return;
  e.preventDefault();
  e.dataTransfer.dropEffect = "move";
  setDragOver(true); // 追加
};

const handleDragLeave = () => {
  setDragOver(false); // 新規追加
};

const handleDropLocal = (e: DragEvent) => {
  if (!isParent) return;
  e.preventDefault();
  e.stopPropagation();
  setDragOver(false); // 追加
  onDrop?.(task.id, prevId);
};
```

#### JSX（青いライン表示）
```tsx
<div
  className={[
    "relative group flex items-center gap-2 py-1 px-2 hover:bg-white/5 transition-colors",
    "min-h-[26px]",
    dragging ? "opacity-50" : "",
    dragOver ? "before:absolute before:top-0 before:left-0 before:right-0 before:h-0.5 before:bg-sky-400 before:shadow-lg before:shadow-sky-400/50" : "",
  ].join(" ")}
  // ...
  onDragOver={handleDragOver}
  onDragLeave={handleDragLeave}
  onDrop={handleDropLocal}
>
```

## 動作

1. **ドラッグ開始**: タスクが半透明（`opacity-50`）になる
2. **ドラッグオーバー**: ドロップ先のタスクの**上部に青いライン**が表示される
3. **ドラッグリーブ**: 青いラインが消える
4. **ドロップ**: タスクが移動し、青いラインが消える

## 視覚的効果

- **色**: `bg-sky-400`（スカイブルー）
- **高さ**: `h-0.5`（2px）
- **シャドウ**: `shadow-lg shadow-sky-400/50`（光る効果）
- **位置**: タスク行の上部（`before:top-0`）
- **実装**: CSS `before` 疑似要素

## テスト

手動テスト:
- [x] TypeScriptコンパイルエラーなし
- [x] 親タスクをドラッグ → 半透明になる
- [x] 別のタスクの上にドラッグオーバー → 青いラインが表示される
- [x] ドラッグリーブ → 青いラインが消える
- [x] ドロップ → タスクが移動し、青いラインが消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)