### PR TITLE
fix: ライトモード/ダークモード表示の改善 (#233)

### DIFF
--- a/frontend/src/features/priority/PriorityTasksPanel.tsx
+++ b/frontend/src/features/priority/PriorityTasksPanel.tsx
@@ -114,7 +114,7 @@ export default function PriorityTasksPanel() {
       style={{ width: `${width}px` }}
       className="
         relative rounded-xl border border-blue-200 bg-blue-50/60 shadow-lg
-        dark:border-blue-900 dark:bg-blue-950/30
+        dark:border-slate-700 dark:bg-slate-800/50
       "
     >
       {/* リサイザー */}
@@ -122,7 +122,7 @@ export default function PriorityTasksPanel() {
         onMouseDown={() => setIsResizing(true)}
         className="
           absolute left-0 top-0 bottom-0 w-1 cursor-col-resize
-          hover:bg-blue-400 active:bg-blue-500 transition-colors
+          hover:bg-blue-400 dark:hover:bg-slate-600 active:bg-blue-500 dark:active:bg-slate-500 transition-colors
         "
         title="ドラッグして幅を調整"
       />
@@ -133,7 +133,7 @@ export default function PriorityTasksPanel() {
             <button
               onClick={() => setIsCollapsed(!isCollapsed)}
               className="
-                text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100
+                text-blue-700 dark:text-slate-300 hover:text-blue-900 dark:hover:text-slate-100
                 transition-transform
               "
               title={isCollapsed ? "展開" : "折りたたむ"}
@@ -148,11 +148,11 @@ export default function PriorityTasksPanel() {
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
               </svg>
             </button>
-            <h2 className="font-semibold text-blue-700 dark:text-blue-300">
+            <h2 className="font-semibold text-blue-700 dark:text-slate-200">
               期限が近いタスク
             </h2>
             <span
-              className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 text-white text-[10px]"
+              className="inline-flex h-4 w-4 items-center justify-center rounded-full bg-blue-600 dark:bg-slate-600 text-white text-[10px]"
               title="期限の近い順に表示します"
               aria-label="説明"
             >
@@ -165,8 +165,8 @@ export default function PriorityTasksPanel() {
               onChange={(e) => setLimit(Number(e.target.value))}
               className="
                 text-xs px-2 py-1 rounded border border-blue-300 bg-white
-                dark:bg-blue-900 dark:border-blue-700 dark:text-blue-100
-                focus:outline-none focus:ring-2 focus:ring-blue-500
+                dark:bg-slate-700 dark:border-slate-600 dark:text-slate-200
+                focus:outline-none focus:ring-2 focus:ring-blue-500 dark:focus:ring-slate-500
               "
               title="表示件数"
             >
@@ -175,7 +175,7 @@ export default function PriorityTasksPanel() {
               <option value={10}>10件</option>
               <option value={15}>15件</option>
             </select>
-            <span className="text-xs text-blue-700/70 dark:text-blue-300/70">
+            <span className="text-xs text-blue-700/70 dark:text-slate-300/70">
               {visible.length}件
             </span>
           </div>
@@ -184,11 +184,11 @@ export default function PriorityTasksPanel() {
         {!isCollapsed && (
           <>
             {isLoading && (
-              <p className="text-sm text-blue-700/70 dark:text-blue-300/70">
+              <p className="text-sm text-blue-700/70 dark:text-slate-300/70">
                 読み込み中…
               </p>
             )}
-            {error && <p className="text-sm text-red-600">読み込みに失敗しました</p>}
+            {error && <p className="text-sm text-red-600 dark:text-red-400">読み込みに失敗しました</p>}
 
             <ul className="space-y-2">
         {visible.map((t) => (
@@ -197,7 +197,7 @@ export default function PriorityTasksPanel() {
             data-testid="priority-item"
             className="
               rounded-lg border border-blue-100 bg-white/80 p-2 transition-colors
-              hover:bg-white dark:border-blue-900/40 dark:bg-blue-900/30 hover:dark:bg-blue-900/40
+              hover:bg-white dark:border-slate-700 dark:bg-slate-700/50 dark:hover:bg-slate-700/70
             "
           >
             <div className="flex items-center gap-2">
@@ -207,39 +207,39 @@ export default function PriorityTasksPanel() {
                 checked={t.status === "completed"}
                 onChange={() => handleToggle(t)}
                 aria-label="完了"
-                className="accent-blue-600"
+                className="accent-blue-600 dark:accent-slate-400"
               />
               <div className="min-w-0 flex-1">
                 <p
                   data-testid="priority-title"
-                  className="truncate text-sm font-medium text-blue-900 dark:text-blue-100"
+                  className="truncate text-sm font-medium text-blue-900 dark:text-slate-100"
                 >
                   {t.title}
                 </p>
                 <div className="flex items-center gap-2 mt-0.5">
-                  <p className="text-xs text-blue-800/70 dark:text-blue-200/70">
+                  <p className="text-xs text-blue-800/70 dark:text-slate-300/70">
                     {formatDeadlineForDisplay(t.deadline)}
                   </p>
                   <span
                     className={[
                       "text-xs px-1.5 py-0.5 rounded font-semibold",
-                      getDeadlineUrgency(t.deadline) === "overdue" && "bg-red-500 text-white",
-                      getDeadlineUrgency(t.deadline) === "urgent" && "bg-orange-500 text-white",
-                      getDeadlineUrgency(t.deadline) === "warning" && "bg-yellow-500 text-white",
-                      getDeadlineUrgency(t.deadline) === "normal" && "bg-blue-500 text-white",
+                      getDeadlineUrgency(t.deadline) === "overdue" && "bg-red-500 dark:bg-red-600 text-white",
+                      getDeadlineUrgency(t.deadline) === "urgent" && "bg-orange-500 dark:bg-orange-600 text-white",
+                      getDeadlineUrgency(t.deadline) === "warning" && "bg-yellow-500 dark:bg-yellow-600 text-white",
+                      getDeadlineUrgency(t.deadline) === "normal" && "bg-blue-500 dark:bg-slate-600 text-white",
                     ]
                       .filter(Boolean)
                       .join(" ")}
                   >
                     {formatDaysUntilDeadline(t.deadline)}
                   </span>
-                  <span className="text-xs text-blue-800/70 dark:text-blue-200/70">
+                  <span className="text-xs text-blue-800/70 dark:text-slate-300/70">
                     進捗 {Math.round(t.progress ?? 0)}%
                   </span>
                 </div>
-                <div className="mt-1 h-2 w-full rounded bg-blue-200/70 dark:bg-blue-900/50">
+                <div className="mt-1 h-2 w-full rounded bg-blue-200/70 dark:bg-slate-900/50">
                   <div
-                    className="h-2 rounded bg-blue-600 dark:bg-blue-400"
+                    className="h-2 rounded bg-blue-600 dark:bg-slate-400"
                     style={{ width: `${clamp(t.progress ?? 0, 0, 100)}%` }}
                   />
                 </div>
@@ -250,7 +250,7 @@ export default function PriorityTasksPanel() {
       </ul>
 
             {!isLoading && visible.length === 0 && (
-              <p className="text-sm text-blue-700/70 dark:text-blue-300/70">
+              <p className="text-sm text-blue-700/70 dark:text-slate-300/70">
                 未完了の優先タスクはありません
               </p>
             )}

--- a/frontend/src/features/tasks/TaskFilterBar.tsx
+++ b/frontend/src/features/tasks/TaskFilterBar.tsx
@@ -21,13 +21,13 @@ export function TaskFilterBar() {
       const label = status
         .map((s) => (s === "not_started" ? "未着手" : s === "in_progress" ? "進行中" : "完了"))
         .join(" , ");
-      chips.push(<span key="status" className="px-3 py-1 text-[11px] rounded-full bg-sky-400/20 text-sky-200 border border-sky-400/30 font-medium backdrop-blur-sm">status: {label}</span>);
+      chips.push(<span key="status" className="px-3 py-1 text-[11px] rounded-full bg-sky-400/20 text-sky-700 dark:text-sky-200 border border-sky-400/30 font-medium backdrop-blur-sm">status: {label}</span>);
     }
-    if (site) chips.push(<span key="site" className="px-3 py-1 text-[11px] rounded-full bg-emerald-400/20 text-emerald-200 border border-emerald-400/30 font-medium backdrop-blur-sm">site: {site}</span>);
-    if (parents_only) chips.push(<span key="parents" className="px-3 py-1 text-[11px] rounded-full bg-purple-400/20 text-purple-200 border border-purple-400/30 font-medium backdrop-blur-sm">上位タスクのみ</span>);
+    if (site) chips.push(<span key="site" className="px-3 py-1 text-[11px] rounded-full bg-emerald-400/20 text-emerald-700 dark:text-emerald-200 border border-emerald-400/30 font-medium backdrop-blur-sm">site: {site}</span>);
+    if (parents_only) chips.push(<span key="parents" className="px-3 py-1 text-[11px] rounded-full bg-purple-400/20 text-purple-700 dark:text-purple-200 border border-purple-400/30 font-medium backdrop-blur-sm">上位タスクのみ</span>);
     if (progress_min || progress_max) {
       chips.push(
-        <span key="progress" className="px-3 py-1 text-[11px] rounded-full bg-amber-400/20 text-amber-200 border border-amber-400/30 font-medium backdrop-blur-sm">
+        <span key="progress" className="px-3 py-1 text-[11px] rounded-full bg-amber-400/20 text-amber-700 dark:text-amber-200 border border-amber-400/30 font-medium backdrop-blur-sm">
           progress: {progress_min || 0}–{progress_max || 100}
         </span>
       );
@@ -75,18 +75,18 @@ export function TaskFilterBar() {
       {/* 見出し＋絞り込み状況／件数表示／全解除 */}
       <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="min-w-0 flex items-center gap-2 flex-wrap">
-          <h2 className="text-sm font-semibold text-white shrink-0">フィルター &amp; 並び替え</h2>
-          <span aria-hidden className="hidden sm:inline h-4 w-px bg-white/20 mx-1" />
-          <span className="text-xs text-slate-400 shrink-0">絞り込み：</span>
+          <h2 className="text-sm font-semibold text-gray-900 dark:text-white shrink-0">フィルター &amp; 並び替え</h2>
+          <span aria-hidden className="hidden sm:inline h-4 w-px bg-gray-300 dark:bg-white/20 mx-1" />
+          <span className="text-xs text-gray-600 dark:text-slate-400 shrink-0">絞り込み：</span>
           <div className="min-w-0 flex items-center gap-1 flex-wrap">
-            {filterChips.length ? filterChips : <span className="text-xs text-slate-500">なし</span>}
+            {filterChips.length ? filterChips : <span className="text-xs text-gray-500 dark:text-slate-500">なし</span>}
           </div>
         </div>
 
         <div className="flex items-center gap-3 shrink-0">
           <button
             type="button"
-            className="text-xs text-sky-400 hover:text-sky-300 font-medium underline decoration-sky-400/30 hover:decoration-sky-300/50 underline-offset-2 transition-colors"
+            className="text-xs text-sky-600 dark:text-sky-400 hover:text-sky-700 dark:hover:text-sky-300 font-medium underline decoration-sky-600/30 dark:decoration-sky-400/30 hover:decoration-sky-700/50 dark:hover:decoration-sky-300/50 underline-offset-2 transition-colors"
             data-testid="filter-reset"
             onClick={() => setSp({}, { replace: true })}
           >
@@ -96,14 +96,14 @@ export function TaskFilterBar() {
       </div>
 
       {/* 本体：12カラム（横一列 / 等間隔気味の割り当て） */}
-      <div className="w-full rounded-2xl border border-white/15 bg-gradient-to-br from-white/10 via-white/5 to-transparent backdrop-blur-md px-4 py-3 shadow-xl">
+      <div className="w-full rounded-2xl border border-gray-200 dark:border-white/15 bg-white/80 dark:bg-gradient-to-br dark:from-white/10 dark:via-white/5 dark:to-transparent backdrop-blur-md px-4 py-3 shadow-xl">
         <div className="grid grid-cols-1 sm:grid-cols-12 gap-3 items-center">
           {/* 1) 現場名（3） */}
           <div className="sm:col-span-3">
             <input
               data-testid="filter-site"
               placeholder="現場名"
-              className="w-full rounded-lg border border-white/20 bg-white/10 text-white placeholder:text-slate-400 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 focus:border-sky-400/50 transition-all backdrop-blur-sm"
+              className="w-full rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-slate-400 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 focus:border-sky-400/50 transition-all backdrop-blur-sm"
               value={site}
               onChange={(e) => setOrDelete("site", e.target.value)}
             />
@@ -111,7 +111,7 @@ export function TaskFilterBar() {
 
           {/* 2) ステータス（3） */}
           <div className="sm:col-span-3 flex justify-start min-w-0">
-            <div role="group" aria-label="ステータスで絞り込み" className="inline-flex rounded-full bg-white/10 p-1 flex-nowrap whitespace-nowrap backdrop-blur-sm">
+            <div role="group" aria-label="ステータスで絞り込み" className="inline-flex rounded-full bg-gray-100 dark:bg-white/10 p-1 flex-nowrap whitespace-nowrap backdrop-blur-sm">
               {allStatuses.map((s) => {
                 const active = status.includes(s);
                 const label = s === "not_started" ? "未着手" : s === "in_progress" ? "進行中" : "完了";
@@ -121,7 +121,7 @@ export function TaskFilterBar() {
                     type="button"
                     aria-pressed={active}
                     onClick={() => toggleStatus(s)}
-                    className={["px-2 sm:px-3 py-1.5 text-[11px] sm:text-xs rounded-full transition-all font-medium", active ? "bg-gradient-to-r from-sky-400 to-emerald-400 text-slate-900 shadow-lg" : "text-slate-300 hover:bg-white/15 hover:text-white"].join(" ")}
+                    className={["px-2 sm:px-3 py-1.5 text-[11px] sm:text-xs rounded-full transition-all font-medium", active ? "bg-gradient-to-r from-sky-400 to-emerald-400 text-slate-900 shadow-lg" : "text-gray-600 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-white/15 hover:text-gray-900 dark:hover:text-white"].join(" ")}
                   >
                     {label}
                   </button>
@@ -131,20 +131,20 @@ export function TaskFilterBar() {
           </div>
 
           {/* 3) 進捗（2） */}
-          <div className="sm:col-span-2 text-xs text-slate-300">
+          <div className="sm:col-span-2 text-xs text-gray-700 dark:text-slate-300">
             <label className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <span className="shrink-0 font-medium">進捗</span>
               <div className="flex items-center gap-2">
-                <input type="number" min={0} max={100} step={1} data-testid="progress-min" className="w-full sm:w-16 rounded-lg border border-white/20 bg-white/10 text-white placeholder:text-slate-500 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_min} onChange={onChangeProgress("progress_min")} placeholder="min" />
-                <span className="shrink-0 text-slate-400">–</span>
-                <input type="number" min={0} max={100} step={1} data-testid="progress-max" className="w-full sm:w-16 rounded-lg border border-white/20 bg-white/10 text-white placeholder:text-slate-500 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_max} onChange={onChangeProgress("progress_max")} placeholder="max" />
+                <input type="number" min={0} max={100} step={1} data-testid="progress-min" className="w-full sm:w-16 rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-slate-500 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_min} onChange={onChangeProgress("progress_min")} placeholder="min" />
+                <span className="shrink-0 text-gray-500 dark:text-slate-400">–</span>
+                <input type="number" min={0} max={100} step={1} data-testid="progress-max" className="w-full sm:w-16 rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-slate-500 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_max} onChange={onChangeProgress("progress_max")} placeholder="max" />
               </div>
             </label>
           </div>
 
           {/* 4) 上位タスクのみ（2） */}
           <div className="sm:col-span-2 flex items-center justify-start">
-            <label className="inline-flex items-center gap-2 text-sm whitespace-nowrap text-slate-200 font-medium cursor-pointer hover:text-white transition-colors" title="上位タスク（親）だけを表示">
+            <label className="inline-flex items-center gap-2 text-sm whitespace-nowrap text-gray-700 dark:text-slate-200 font-medium cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors" title="上位タスク（親）だけを表示">
               <input type="checkbox" checked={parents_only} onChange={toggleParentsOnly} className="accent-sky-400 w-4 h-4 rounded cursor-pointer" data-testid="filter-parents-only" />
               <span>上位のみ</span>
             </label>
@@ -152,18 +152,18 @@ export function TaskFilterBar() {
 
           {/* 5) 並び基準（1） */}
           <div className="sm:col-span-1 flex justify-start">
-            <select data-testid="order_by" className="w-full max-w-[9rem] rounded-lg border border-white/20 bg-white/10 text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={order_by} onChange={(e) => setOrDelete("order_by", e.target.value)}>
-              <option value="deadline" className="bg-slate-800">期限</option>
-              <option value="progress" className="bg-slate-800">進捗</option>
-              <option value="created_at" className="bg-slate-800">作成日</option>
+            <select data-testid="order_by" className="w-full max-w-[9rem] rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={order_by} onChange={(e) => setOrDelete("order_by", e.target.value)}>
+              <option value="deadline" className="bg-white dark:bg-slate-800">期限</option>
+              <option value="progress" className="bg-white dark:bg-slate-800">進捗</option>
+              <option value="created_at" className="bg-white dark:bg-slate-800">作成日</option>
             </select>
           </div>
 
           {/* 6) 昇降（1） */}
           <div className="sm:col-span-1 flex justify-start">
-            <select data-testid="dir" className="w-full max-w-[7rem] rounded-lg border border-white/20 bg-white/10 text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={dir} onChange={(e) => setOrDelete("dir", e.target.value)}>
-              <option value="asc" className="bg-slate-800">昇順</option>
-              <option value="desc" className="bg-slate-800">降順</option>
+            <select data-testid="dir" className="w-full max-w-[7rem] rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={dir} onChange={(e) => setOrDelete("dir", e.target.value)}>
+              <option value="asc" className="bg-white dark:bg-slate-800">昇順</option>
+              <option value="desc" className="bg-white dark:bg-slate-800">降順</option>
             </select>
           </div>
         </div>

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -105,16 +105,16 @@ const TaskList: PageComponent = () => {
           {/* Guest Banner */}
           {isGuest && (
             <div
-              className="mb-6 rounded-2xl border border-amber-400/30 bg-gradient-to-r from-amber-500/15 via-orange-500/10 to-amber-500/15 px-5 py-4 backdrop-blur-md shadow-lg shadow-amber-500/10 animate-[fadeIn_0.6s_ease-out]"
+              className="mb-6 rounded-2xl border border-amber-300 dark:border-amber-400/30 bg-gradient-to-r from-amber-100 via-orange-50 to-amber-100 dark:from-amber-500/15 dark:via-orange-500/10 dark:to-amber-500/15 px-5 py-4 backdrop-blur-md shadow-lg shadow-amber-200/50 dark:shadow-amber-500/10 animate-[fadeIn_0.6s_ease-out]"
               role="note"
             >
               <div className="flex items-center gap-3">
                 <span className="flex-shrink-0 flex h-2 w-2">
-                  <span className="animate-ping absolute inline-flex h-2 w-2 rounded-full bg-amber-400 opacity-75"></span>
-                  <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-400"></span>
+                  <span className="animate-ping absolute inline-flex h-2 w-2 rounded-full bg-amber-500 dark:bg-amber-400 opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-2 w-2 bg-amber-500 dark:bg-amber-400"></span>
                 </span>
-                <p className="text-sm font-medium text-amber-100">
-                  これは<strong className="mx-1 text-amber-200">ゲスト環境</strong>です。データは定期的に初期化される場合があります。
+                <p className="text-sm font-medium text-amber-800 dark:text-amber-100">
+                  これは<strong className="mx-1 text-amber-900 dark:text-amber-200">ゲスト環境</strong>です。データは定期的に初期化される場合があります。
                 </p>
               </div>
             </div>
@@ -160,7 +160,7 @@ const TaskList: PageComponent = () => {
           <div className="grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,1fr)_24rem]">
             {/* Task List Section - Workflowy Style */}
             <section className="relative z-10 animate-[fadeIn_1s_ease-out_0.2s_both]">
-              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-gradient-to-br dark:from-white/5 dark:via-white/[0.02] dark:to-transparent backdrop-blur-sm shadow-xl overflow-hidden">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/10 bg-white dark:bg-slate-900/80 backdrop-blur-sm shadow-xl overflow-hidden">
                 <WorkflowyTaskTree tree={tasks} />
               </div>
             </section>
@@ -173,7 +173,7 @@ const TaskList: PageComponent = () => {
                 showPriorityPanel ? "block" : "hidden",
               ].join(" ")}
             >
-              <div className="rounded-2xl border border-gray-200 dark:border-white/15 bg-white dark:bg-gradient-to-br dark:from-white/10 dark:via-white/5 dark:to-transparent backdrop-blur-xl shadow-2xl overflow-hidden animate-[fadeIn_1.2s_ease-out_0.4s_both]">
+              <div className="rounded-2xl border border-gray-200 dark:border-white/15 bg-white dark:bg-slate-900/80 backdrop-blur-xl shadow-2xl overflow-hidden animate-[fadeIn_1.2s_ease-out_0.4s_both]">
                 <PriorityTasksPanel />
               </div>
             </aside>


### PR DESCRIPTION
## Summary
- ライトモード時のゲスト環境とフィルターバーの文字色を視認性の高い色に調整
- ダークモード時のタスク一覧と期限が近いタスクパネルの配色を暗い雰囲気に統一

## 変更内容

### ライトモード
- ゲスト環境バナーの文字色を調整（白→amber-800/900で視認性向上）
- フィルターバーの見出しと文字色を調整（white→gray-900/600で視認性向上）
- フィルターチップの文字色を調整（各色に700を追加し視認性向上）
- フィルターバーの背景色を調整（透明→white/80で視認性向上）
- 全ての入力フィールドとボタンにライトモード用の色を追加

### ダークモード
- タスク一覧の背景色を暗く調整（white/5→slate-900/80で暗い雰囲気に）
- 優先パネルの配色をslate系に統一（blue系→slate系で統一感向上）
- 期限が近いタスクのバッジ色をダークモードに適応（各urgency levelにdark:クラス追加）
- プログレスバーの色をslate系に調整（blue→slateで統一）

## Test plan
- [ ] ライトモードでゲスト環境バナーの文字が見えることを確認
- [ ] ライトモードでフィルターバーの全ての要素が見えることを確認
- [ ] ダークモードでタスク一覧が暗い雰囲気になっていることを確認
- [ ] ダークモードで期限が近いタスクパネルの色が適切に表示されることを確認
- [ ] ダークモードで全ての文字が視認できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)