### PR TITLE
feat: パスワード再設定UI機能を実装

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,5 +21,13 @@ RAILS_LOG_LEVEL=debug
 SENTRY_DSN=
 APP_VERSION=
 
+# Email Configuration (Amazon SES recommended)
+SMTP_ADDRESS=email-smtp.ap-northeast-1.amazonaws.com
+SMTP_PORT=587
+SMTP_DOMAIN=genba-tasks.com
+SMTP_USERNAME=
+SMTP_PASSWORD=
+MAIL_FROM=noreply@genba-tasks.com
+
 # Rails Credentials
 RAILS_MASTER_KEY=

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -51,12 +51,28 @@ Rails.application.configure do
   # ===============================================================
 
   # Mailer設定
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
+  config.action_mailer.delivery_method = :smtp
   config.action_mailer.default_url_options = {
     host: ENV.fetch("APP_HOST", "app.genba-tasks.com"),
     protocol: 'https'
   }
-  # config.action_mailer.smtp_settings = { ... }
+
+  # SMTP設定（Amazon SES推奨）
+  config.action_mailer.smtp_settings = {
+    address: ENV.fetch("SMTP_ADDRESS", "email-smtp.ap-northeast-1.amazonaws.com"),
+    port: ENV.fetch("SMTP_PORT", 587).to_i,
+    domain: ENV.fetch("SMTP_DOMAIN", "genba-tasks.com"),
+    user_name: ENV["SMTP_USERNAME"],
+    password: ENV["SMTP_PASSWORD"],
+    authentication: :login,
+    enable_starttls_auto: true
+  }
+
+  # メール送信元
+  config.action_mailer.default_options = {
+    from: ENV.fetch("MAIL_FROM", "noreply@genba-tasks.com")
+  }
 
   # I18n fallbacks
   config.i18n.fallbacks = true

--- a/frontend/src/pages/ForgotPassword.tsx
+++ b/frontend/src/pages/ForgotPassword.tsx
@@ -1,0 +1,169 @@
+import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import api from "../lib/apiClient";
+
+type FieldErr = string | null;
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const [errTop, setErrTop] = useState<string | null>(null);
+  const [errEmail, setErrEmail] = useState<FieldErr>(null);
+
+  const emailInvalid = useMemo(() => {
+    if (email.trim() === "") return "メールアドレスを入力してください。";
+    if (!emailRe.test(email)) return "メールアドレスの形式が正しくありません。";
+    return null;
+  }, [email]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrTop(null);
+
+    const eErr = emailInvalid;
+    setErrEmail(eErr);
+    if (eErr) return;
+
+    setSubmitting(true);
+    try {
+      await api.post("/auth/password", {
+        email: email.trim(),
+        redirect_url: `${window.location.origin}/reset-password`,
+      });
+
+      setSuccess(true);
+    } catch (err: unknown) {
+      const error = err as { response?: { data?: { errors?: { full_messages?: string[] } } }; message?: string };
+      const msg =
+        error?.response?.data?.errors?.full_messages?.[0] ??
+        error?.message ??
+        "パスワードリセットメールの送信に失敗しました。";
+      setErrTop(String(msg));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center px-4">
+        <div className="w-full max-w-md">
+          <div className="bg-white dark:bg-gray-800 shadow rounded-2xl p-6">
+            <div className="text-center">
+              <svg
+                className="mx-auto h-12 w-12 text-green-600 dark:text-green-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              <h1 className="mt-4 text-xl font-bold text-gray-900 dark:text-gray-100">
+                メールを送信しました
+              </h1>
+              <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+                パスワード再設定のリンクをメールでお送りしました。
+                <br />
+                メールをご確認の上、リンクをクリックしてパスワードを再設定してください。
+              </p>
+              <p className="mt-4 text-xs text-gray-500 dark:text-gray-500">
+                メールが届かない場合は、迷惑メールフォルダをご確認ください。
+              </p>
+            </div>
+
+            <div className="mt-6 text-center">
+              <Link
+                to="/login"
+                className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                ログインページに戻る
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-2xl p-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 text-center">
+            パスワードを忘れた方
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 text-center mt-2">
+            登録したメールアドレスを入力してください。
+            <br />
+            パスワード再設定のリンクをお送りします。
+          </p>
+
+          {errTop && (
+            <div
+              role="alert"
+              className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {errTop}
+            </div>
+          )}
+
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                メールアドレス
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                className={`mt-1 block w-full rounded-md border px-3 py-2 text-sm outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100
+                  ${errEmail ? "border-red-300 focus:ring-red-200 dark:border-red-600 dark:focus:ring-red-800" : "border-gray-300 dark:border-gray-600 focus:ring-blue-200 dark:focus:ring-blue-800"}`}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                aria-invalid={!!errEmail}
+                aria-describedby={errEmail ? "email-error" : undefined}
+                disabled={submitting}
+                required
+                autoFocus
+              />
+              {errEmail && (
+                <p id="email-error" className="mt-1 text-xs text-red-600">
+                  {errEmail}
+                </p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              disabled={submitting}
+              className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-60 hover:bg-blue-700"
+            >
+              {submitting && (
+                <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" strokeWidth="4" opacity="0.25" />
+                  <path d="M22 12a10 10 0 0 1-10 10" fill="none" stroke="currentColor" strokeWidth="4" />
+                </svg>
+              )}
+              パスワード再設定メールを送信
+            </button>
+          </form>
+
+          <p className="mt-4 text-center text-xs text-gray-600 dark:text-gray-400">
+            <Link to="/login" className="text-blue-600 dark:text-blue-400 hover:underline">
+              ログインページに戻る
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -207,12 +207,19 @@ export default function Login() {
             </div>
           </form>
 
-          <p className="mt-4 text-center text-xs text-gray-600 dark:text-gray-400">
-            アカウントをお持ちでない方は{" "}
-            <a href="/register" className="text-blue-600 dark:text-blue-400 hover:underline">
-              新規登録
-            </a>
-          </p>
+          <div className="mt-4 space-y-2">
+            <p className="text-center text-xs text-gray-600 dark:text-gray-400">
+              <a href="/forgot-password" className="text-blue-600 dark:text-blue-400 hover:underline">
+                パスワードをお忘れの方
+              </a>
+            </p>
+            <p className="text-center text-xs text-gray-600 dark:text-gray-400">
+              アカウントをお持ちでない方は{" "}
+              <a href="/register" className="text-blue-600 dark:text-blue-400 hover:underline">
+                新規登録
+              </a>
+            </p>
+          </div>
         </div>
 
         <p className="mt-3 text-center text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,193 @@
+import { useMemo, useState, useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import api from "../lib/apiClient";
+
+type FieldErr = string | null;
+
+export default function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [showPw, setShowPw] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [errTop, setErrTop] = useState<string | null>(null);
+  const [errPw, setErrPw] = useState<FieldErr>(null);
+  const [errPwConfirm, setErrPwConfirm] = useState<FieldErr>(null);
+
+  // URLパラメータからトークン情報を取得
+  const resetToken = searchParams.get("reset_password_token");
+  const clientId = searchParams.get("client_id");
+  const uid = searchParams.get("uid");
+
+  useEffect(() => {
+    if (!resetToken) {
+      setErrTop("無効なリンクです。パスワード再設定メールからアクセスしてください。");
+    }
+  }, [resetToken]);
+
+  const pwInvalid = useMemo(() => {
+    if (password.trim() === "") return "パスワードを入力してください。";
+    if (password.length < 8) return "パスワードは8文字以上で入力してください。";
+    return null;
+  }, [password]);
+
+  const pwConfirmInvalid = useMemo(() => {
+    if (passwordConfirmation.trim() === "") return "確認用パスワードを入力してください。";
+    if (password !== passwordConfirmation) return "パスワードが一致しません。";
+    return null;
+  }, [password, passwordConfirmation]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrTop(null);
+
+    const pErr = pwInvalid;
+    const pcErr = pwConfirmInvalid;
+    setErrPw(pErr);
+    setErrPwConfirm(pcErr);
+    if (pErr || pcErr || !resetToken) return;
+
+    setSubmitting(true);
+    try {
+      await api.put("/auth/password", {
+        password,
+        password_confirmation: passwordConfirmation,
+        reset_password_token: resetToken,
+      }, {
+        headers: {
+          ...(clientId && { client: clientId }),
+          ...(uid && { uid }),
+        },
+      });
+
+      // 成功したらログインページへ
+      navigate("/login", {
+        replace: true,
+        state: { message: "パスワードを再設定しました。新しいパスワードでログインしてください。" },
+      });
+    } catch (err: unknown) {
+      const error = err as { response?: { data?: { errors?: { full_messages?: string[] } } }; message?: string };
+      const msg =
+        error?.response?.data?.errors?.full_messages?.[0] ??
+        error?.message ??
+        "パスワードの再設定に失敗しました。リンクの有効期限が切れている可能性があります。";
+      setErrTop(String(msg));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center px-4">
+      <div className="w-full max-w-md">
+        <div className="bg-white dark:bg-gray-800 shadow rounded-2xl p-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 text-center">
+            パスワード再設定
+          </h1>
+          <p className="text-sm text-gray-600 dark:text-gray-400 text-center mt-2">
+            新しいパスワードを入力してください
+          </p>
+
+          {errTop && (
+            <div
+              role="alert"
+              className="mt-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {errTop}
+            </div>
+          )}
+
+          <form className="mt-6 space-y-4" onSubmit={handleSubmit} noValidate>
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                新しいパスワード
+              </label>
+              <div className="mt-1 relative">
+                <input
+                  id="password"
+                  name="password"
+                  type={showPw ? "text" : "password"}
+                  autoComplete="new-password"
+                  className={`block w-full rounded-md border px-3 py-2 pr-20 text-sm outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100
+                    ${errPw ? "border-red-300 focus:ring-red-200 dark:border-red-600 dark:focus:ring-red-800" : "border-gray-300 dark:border-gray-600 focus:ring-blue-200 dark:focus:ring-blue-800"}`}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  aria-invalid={!!errPw}
+                  aria-describedby={errPw ? "password-error" : undefined}
+                  disabled={submitting || !resetToken}
+                  required
+                  autoFocus
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPw((v) => !v)}
+                  className="absolute inset-y-0 right-2 my-auto text-xs px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600"
+                  aria-pressed={showPw}
+                  disabled={!resetToken}
+                >
+                  {showPw ? "隠す" : "表示"}
+                </button>
+              </div>
+              {errPw && (
+                <p id="password-error" className="mt-1 text-xs text-red-600">
+                  {errPw}
+                </p>
+              )}
+              <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                8文字以上で入力してください
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="password-confirm" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                新しいパスワード（確認）
+              </label>
+              <input
+                id="password-confirm"
+                name="password-confirmation"
+                type={showPw ? "text" : "password"}
+                autoComplete="new-password"
+                className={`mt-1 block w-full rounded-md border px-3 py-2 text-sm outline-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100
+                  ${errPwConfirm ? "border-red-300 focus:ring-red-200 dark:border-red-600 dark:focus:ring-red-800" : "border-gray-300 dark:border-gray-600 focus:ring-blue-200 dark:focus:ring-blue-800"}`}
+                value={passwordConfirmation}
+                onChange={(e) => setPasswordConfirmation(e.target.value)}
+                aria-invalid={!!errPwConfirm}
+                aria-describedby={errPwConfirm ? "password-confirm-error" : undefined}
+                disabled={submitting || !resetToken}
+                required
+              />
+              {errPwConfirm && (
+                <p id="password-confirm-error" className="mt-1 text-xs text-red-600">
+                  {errPwConfirm}
+                </p>
+              )}
+            </div>
+
+            <button
+              type="submit"
+              disabled={submitting || !resetToken}
+              className="w-full inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white text-sm font-medium disabled:opacity-60 hover:bg-blue-700"
+            >
+              {submitting && (
+                <svg className="h-4 w-4 animate-spin" viewBox="0 0 24 24" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10" fill="none" stroke="currentColor" strokeWidth="4" opacity="0.25" />
+                  <path d="M22 12a10 10 0 0 1-10 10" fill="none" stroke="currentColor" strokeWidth="4" />
+                </svg>
+              )}
+              パスワードを再設定
+            </button>
+          </form>
+
+          <p className="mt-4 text-center text-xs text-gray-600 dark:text-gray-400">
+            <a href="/login" className="text-blue-600 dark:text-blue-400 hover:underline">
+              ログインページに戻る
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -2,6 +2,8 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Login from "../pages/Login";
 import Register from "../pages/Register";
+import ForgotPassword from "../pages/ForgotPassword";
+import ResetPassword from "../pages/ResetPassword";
 import TaskList from "../pages/TaskList";
 import Layout from "../components/Layout";
 import RequireAuth from "../components/RequireAuth";
@@ -21,6 +23,8 @@ export const AppRouter = () => {
         <Route path="/signin" element={<Navigate to="/login" replace />} />
         <Route path="/register" element={<Register />} />
         <Route path="/signup" element={<Navigate to="/register" replace />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
 
         {/* 認証ガード配下（レイアウトも保護下に置く） */}
         <Route element={<RequireAuth />}>


### PR DESCRIPTION
## 概要
ユーザーがパスワードを忘れた際に、自分でパスワードをリセットできる機能を追加しました。

Closes #244

## 主な変更点

### フロントエンド

#### 1. ForgotPasswordページ ([frontend/src/pages/ForgotPassword.tsx](frontend/src/pages/ForgotPassword.tsx))
- メールアドレス入力フォーム
- バリデーション（メールアドレス形式チェック）
- API呼び出し（`POST /auth/password`）
- 送信成功時の確認画面表示
- エラーハンドリング

#### 2. ResetPasswordページ ([frontend/src/pages/ResetPassword.tsx](frontend/src/pages/ResetPassword.tsx))
- URLパラメータからトークン情報を取得
  - `reset_password_token`
  - `client_id`
  - `uid`
- 新しいパスワード入力フォーム（表示/非表示切り替え）
- パスワード確認入力
- バリデーション
  - 8文字以上
  - パスワード一致確認
- API呼び出し（`PUT /auth/password`）
- 成功時はログインページへリダイレクト
- 無効なトークンのエラー表示

#### 3. ルーティング ([frontend/src/router/AppRouter.tsx](frontend/src/router/AppRouter.tsx))
- `/forgot-password` ルート追加
- `/reset-password` ルート追加
- 認証不要ルートとして設定

#### 4. Loginページ ([frontend/src/pages/Login.tsx](frontend/src/pages/Login.tsx))
- 「パスワードをお忘れの方」リンク追加

### バックエンド

#### 5. メール送信設定 ([backend/config/environments/production.rb](backend/config/environments/production.rb))
- SMTP配信方法を設定
- Amazon SES対応の設定
  - address, port, domain
  - 認証情報（環境変数から取得）
  - STARTTLS有効化
- デフォルト送信元メールアドレス設定
- エラーレポート有効化

#### 6. 環境変数 ([backend/.env.example](backend/.env.example))
新規追加:
- `SMTP_ADDRESS` - SMTPサーバーアドレス
- `SMTP_PORT` - SMTPポート（デフォルト: 587）
- `SMTP_DOMAIN` - ドメイン名
- `SMTP_USERNAME` - SMTP認証ユーザー名
- `SMTP_PASSWORD` - SMTP認証パスワード
- `MAIL_FROM` - 送信元メールアドレス

## 使用フロー

1. **パスワード忘れ申請**
   - ログインページから「パスワードをお忘れの方」をクリック
   - メールアドレスを入力して送信

2. **メール受信**
   - 登録メールアドレスにパスワード再設定リンクが送信される
   - リンクの有効期限はdevise_token_authのデフォルト設定（6時間）

3. **パスワード再設定**
   - メールのリンクをクリック
   - 新しいパスワードを入力（8文字以上）
   - パスワード確認入力

4. **ログイン**
   - ログインページへ自動リダイレクト
   - 新しいパスワードでログイン

## UI/UX

- **デザイン統一**: 既存のLogin/Registerページと同じデザインスタイル
- **ダークモード対応**: 全ページでダークモードに対応
- **レスポンシブ**: モバイル・デスクトップ両対応
- **アクセシビリティ**:
  - aria-invalid, aria-describedby属性
  - フォームバリデーションエラーの明確な表示
  - キーボード操作対応

## セキュリティ

- ✅ パスワードの表示/非表示切り替え
- ✅ パスワード最小8文字
- ✅ パスワード一致確認
- ✅ トークン検証（バックエンド側）
- ✅ HTTPSでのメール送信（本番環境）

## 本番環境での設定

### 必須: Amazon SES設定

1. **SESセットアップ**
   - AWS SESでドメインまたはメールアドレスを検証
   - 本番アクセス申請（サンドボックスモードを解除）

2. **SMTP認証情報取得**
   - AWS SES > SMTP Settings
   - SMTP認証情報を作成
   - ユーザー名とパスワードを取得

3. **環境変数設定**
   
   ECSタスク定義またはGitHub Secretsに追加:
   ```
   SMTP_ADDRESS=email-smtp.ap-northeast-1.amazonaws.com
   SMTP_PORT=587
   SMTP_DOMAIN=genba-tasks.com
   SMTP_USERNAME=<SES SMTP Username>
   SMTP_PASSWORD=<SES SMTP Password>
   MAIL_FROM=noreply@genba-tasks.com
   ```

4. **SPF/DKIM設定**
   - ドメインのDNSにSPF/DKIMレコードを追加
   - メールの到達率向上とスパム判定回避

### 動作確認

**開発環境**:
Railsコンソールでメール送信テスト:
```ruby
user = User.first
user.send_reset_password_instructions
```

**本番環境**:
1. ログインページから「パスワードをお忘れの方」をクリック
2. 登録済みメールアドレスを入力
3. メールが届くことを確認
4. リンクをクリックして再設定完了を確認

## Test plan
- [x] ForgotPasswordページ作成
- [x] ResetPasswordページ作成
- [x] ルーティング追加
- [x] Loginページにリンク追加
- [x] メール送信設定追加
- [ ] 開発環境でのメール送信テスト
- [ ] 本番環境でのSES設定
- [ ] エンドツーエンドテスト（メール受信→リンククリック→パスワード変更→ログイン）

## スクリーンショット

（実装後に追加予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)