### PR TITLE
fix: ダークモード時のフィルターバーの色を改善

### DIFF
--- a/frontend/src/features/tasks/TaskFilterBar.tsx
+++ b/frontend/src/features/tasks/TaskFilterBar.tsx
@@ -96,14 +96,14 @@ export function TaskFilterBar() {
       </div>
 
       {/* 本体：12カラム（横一列 / 等間隔気味の割り当て） */}
-      <div className="w-full rounded-2xl border border-gray-200 dark:border-white/15 bg-white/80 dark:bg-gradient-to-br dark:from-white/10 dark:via-white/5 dark:to-transparent backdrop-blur-md px-4 py-3 shadow-xl">
+      <div className="w-full rounded-2xl border border-gray-200 dark:border-slate-700 bg-white/80 dark:bg-slate-800/90 backdrop-blur-md px-4 py-3 shadow-xl">
         <div className="grid grid-cols-1 sm:grid-cols-12 gap-3 items-center">
           {/* 1) 現場名（3） */}
           <div className="sm:col-span-3">
             <input
               data-testid="filter-site"
               placeholder="現場名"
-              className="w-full rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-slate-400 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 focus:border-sky-400/50 transition-all backdrop-blur-sm"
+              className="w-full rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder:text-gray-400 dark:placeholder:text-slate-400 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 focus:border-sky-400/50 transition-all backdrop-blur-sm"
               value={site}
               onChange={(e) => setOrDelete("site", e.target.value)}
             />
@@ -111,7 +111,7 @@ export function TaskFilterBar() {
 
           {/* 2) ステータス（3） */}
           <div className="sm:col-span-3 flex justify-start min-w-0">
-            <div role="group" aria-label="ステータスで絞り込み" className="inline-flex rounded-full bg-gray-100 dark:bg-white/10 p-1 flex-nowrap whitespace-nowrap backdrop-blur-sm">
+            <div role="group" aria-label="ステータスで絞り込み" className="inline-flex rounded-full bg-gray-100 dark:bg-slate-700/80 p-1 flex-nowrap whitespace-nowrap backdrop-blur-sm">
               {allStatuses.map((s) => {
                 const active = status.includes(s);
                 const label = s === "not_started" ? "未着手" : s === "in_progress" ? "進行中" : "完了";
@@ -121,7 +121,7 @@ export function TaskFilterBar() {
                     type="button"
                     aria-pressed={active}
                     onClick={() => toggleStatus(s)}
-                    className={["px-2 sm:px-3 py-1.5 text-[11px] sm:text-xs rounded-full transition-all font-medium", active ? "bg-gradient-to-r from-sky-400 to-emerald-400 text-slate-900 shadow-lg" : "text-gray-600 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-white/15 hover:text-gray-900 dark:hover:text-white"].join(" ")}
+                    className={["px-2 sm:px-3 py-1.5 text-[11px] sm:text-xs rounded-full transition-all font-medium", active ? "bg-gradient-to-r from-sky-400 to-emerald-400 text-slate-900 shadow-lg" : "text-gray-600 dark:text-slate-300 hover:bg-gray-200 dark:hover:bg-slate-600 hover:text-gray-900 dark:hover:text-slate-100"].join(" ")}
                   >
                     {label}
                   </button>
@@ -131,20 +131,20 @@ export function TaskFilterBar() {
           </div>
 
           {/* 3) 進捗（2） */}
-          <div className="sm:col-span-2 text-xs text-gray-700 dark:text-slate-300">
+          <div className="sm:col-span-2 text-xs text-gray-700 dark:text-slate-200">
             <label className="flex flex-col gap-2 sm:flex-row sm:items-center">
               <span className="shrink-0 font-medium">進捗</span>
               <div className="flex items-center gap-2">
-                <input type="number" min={0} max={100} step={1} data-testid="progress-min" className="w-full sm:w-16 rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-slate-500 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_min} onChange={onChangeProgress("progress_min")} placeholder="min" />
+                <input type="number" min={0} max={100} step={1} data-testid="progress-min" className="w-full sm:w-16 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder:text-gray-400 dark:placeholder:text-slate-400 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_min} onChange={onChangeProgress("progress_min")} placeholder="min" />
                 <span className="shrink-0 text-gray-500 dark:text-slate-400">–</span>
-                <input type="number" min={0} max={100} step={1} data-testid="progress-max" className="w-full sm:w-16 rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-slate-500 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_max} onChange={onChangeProgress("progress_max")} placeholder="max" />
+                <input type="number" min={0} max={100} step={1} data-testid="progress-max" className="w-full sm:w-16 rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder:text-gray-400 dark:placeholder:text-slate-400 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm" value={progress_max} onChange={onChangeProgress("progress_max")} placeholder="max" />
               </div>
             </label>
           </div>
 
           {/* 4) 上位タスクのみ（2） */}
           <div className="sm:col-span-2 flex items-center justify-start">
-            <label className="inline-flex items-center gap-2 text-sm whitespace-nowrap text-gray-700 dark:text-slate-200 font-medium cursor-pointer hover:text-gray-900 dark:hover:text-white transition-colors" title="上位タスク（親）だけを表示">
+            <label className="inline-flex items-center gap-2 text-sm whitespace-nowrap text-gray-700 dark:text-slate-200 font-medium cursor-pointer hover:text-gray-900 dark:hover:text-slate-100 transition-colors" title="上位タスク（親）だけを表示">
               <input type="checkbox" checked={parents_only} onChange={toggleParentsOnly} className="accent-sky-400 w-4 h-4 rounded cursor-pointer" data-testid="filter-parents-only" />
               <span>上位のみ</span>
             </label>
@@ -152,7 +152,7 @@ export function TaskFilterBar() {
 
           {/* 5) 並び基準（1） */}
           <div className="sm:col-span-1 flex justify-start">
-            <select data-testid="order_by" className="w-full max-w-[9rem] rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={order_by} onChange={(e) => setOrDelete("order_by", e.target.value)}>
+            <select data-testid="order_by" className="w-full max-w-[9rem] rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={order_by} onChange={(e) => setOrDelete("order_by", e.target.value)}>
               <option value="deadline" className="bg-white dark:bg-slate-800">期限</option>
               <option value="progress" className="bg-white dark:bg-slate-800">進捗</option>
               <option value="created_at" className="bg-white dark:bg-slate-800">作成日</option>
@@ -161,7 +161,7 @@ export function TaskFilterBar() {
 
           {/* 6) 昇降（1） */}
           <div className="sm:col-span-1 flex justify-start">
-            <select data-testid="dir" className="w-full max-w-[7rem] rounded-lg border border-gray-300 dark:border-white/20 bg-white dark:bg-white/10 text-gray-900 dark:text-white px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={dir} onChange={(e) => setOrDelete("dir", e.target.value)}>
+            <select data-testid="dir" className="w-full max-w-[7rem] rounded-lg border border-gray-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-sky-400/50 backdrop-blur-sm font-medium cursor-pointer" value={dir} onChange={(e) => setOrDelete("dir", e.target.value)}>
               <option value="asc" className="bg-white dark:bg-slate-800">昇順</option>
               <option value="desc" className="bg-white dark:bg-slate-800">降順</option>
             </select>


### PR DESCRIPTION
## 概要
ダークモード時のフィルターバーの背景色と文字色がライトモードっぽく違和感があった問題を修正しました。

## 変更内容

### フィルターバー本体
- 背景色: `dark:bg-gradient-to-br dark:from-white/10 dark:via-white/5 dark:to-transparent` → `dark:bg-slate-800/90`
- ボーダー: `dark:border-white/15` → `dark:border-slate-700`

### 入力フィールド（現場名、進捗入力）
- 背景色: `dark:bg-white/10` → `dark:bg-slate-700`
- ボーダー: `dark:border-white/20` → `dark:border-slate-600`
- テキスト色: `dark:text-white` → `dark:text-slate-100`

### ステータスボタン
- 背景色: `dark:bg-white/10` → `dark:bg-slate-700/80`
- ホバー背景: `dark:hover:bg-white/15` → `dark:hover:bg-slate-600`
- ホバーテキスト: `dark:hover:text-white` → `dark:hover:text-slate-100`

### セレクトボックス（並び基準、昇降）
- 背景色: `dark:bg-white/10` → `dark:bg-slate-700`
- ボーダー: `dark:border-white/20` → `dark:border-slate-600`
- テキスト色: `dark:text-white` → `dark:text-slate-100`

### その他
- 進捗ラベル: `dark:text-slate-300` → `dark:text-slate-200`（視認性向上）
- チェックボックスラベルのホバー: `dark:hover:text-white` → `dark:hover:text-slate-100`

## テスト計画
- [ ] ライトモードでの表示が変わっていないことを確認
- [ ] ダークモードで各要素が適切な色で表示されることを確認
- [ ] ホバー時の色変化が適切であることを確認
- [ ] フィルター機能が正常に動作することを確認

## スクリーンショット
修正後のダークモードでフィルターバーがslate系の色で統一され、違和感なく馴染むようになります。

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)