### PR TITLE
feat: タスク期限通知機能を実装

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,6 +4,8 @@ import { Link } from "react-router-dom";
 import useAuth from "../providers/useAuth";
 import { useSidebar } from "../contexts/SidebarContext";
 import { useDarkMode } from "../hooks/useDarkMode";
+import { useNotifications } from "../features/notifications/useNotifications";
+import { NotificationCenter } from "../features/notifications/NotificationCenter";
 
 const HEADER_H = "h-14";
 
@@ -17,6 +19,9 @@ export default function Header({ showDemoBadge = true }: HeaderProps) {
   const { authed, uid, name, signOut } = useAuth();
   const { toggle } = useSidebar();
   const { isDark, toggle: toggleDark } = useDarkMode();
+  const { unreadCount } = useNotifications();
+
+  const [isNotificationOpen, setIsNotificationOpen] = useState(false);
 
   const handleLogout = async () => {
     qc.clear();
@@ -89,6 +94,42 @@ export default function Header({ showDemoBadge = true }: HeaderProps) {
             >
               デモモード
             </span>
+          )}
+
+          {/* 通知ベル */}
+          {authed && (
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => setIsNotificationOpen(!isNotificationOpen)}
+                className="p-2 hover:bg-white/10 rounded transition-colors relative"
+                aria-label="通知"
+                title="通知"
+              >
+                <svg
+                  className="w-5 h-5"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+                  />
+                </svg>
+                {unreadCount > 0 && (
+                  <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center font-semibold">
+                    {unreadCount > 9 ? "9+" : unreadCount}
+                  </span>
+                )}
+              </button>
+              <NotificationCenter
+                isOpen={isNotificationOpen}
+                onClose={() => setIsNotificationOpen(false)}
+              />
+            </div>
           )}
 
           {/* ダークモード切り替えボタン */}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -127,6 +127,14 @@ const Sidebar = () => {
                 アカウント
               </NavLink>
               <NavLink
+                to="/notifications"
+                className={({ isActive }) =>
+                  isActive ? "font-semibold text-blue-700 dark:text-blue-400" : "hover:underline"
+                }
+              >
+                通知設定
+              </NavLink>
+              <NavLink
                 to="/help"
                 className={({ isActive }) =>
                   isActive ? "font-semibold text-blue-700 dark:text-blue-400" : "hover:underline"

--- a/frontend/src/features/notifications/NotificationCenter.tsx
+++ b/frontend/src/features/notifications/NotificationCenter.tsx
@@ -1,0 +1,190 @@
+// features/notifications/NotificationCenter.tsx - 通知センターUI
+import { useEffect, useRef } from "react";
+import type { Notification } from "../../types";
+import { useNotifications } from "./useNotifications";
+
+type NotificationCenterProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function NotificationCenter({ isOpen, onClose }: NotificationCenterProps) {
+  const {
+    notifications,
+    unreadCount,
+    markAsRead,
+    markAllAsRead,
+    deleteNotification,
+    clearAll,
+  } = useNotifications();
+
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // 外側クリックで閉じる
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      ref={panelRef}
+      className="absolute right-0 top-full mt-2 w-96 max-h-[600px] bg-white dark:bg-slate-800 rounded-lg shadow-2xl border border-gray-200 dark:border-slate-700 overflow-hidden z-50"
+    >
+      {/* ヘッダー */}
+      <div className="px-4 py-3 bg-gradient-to-r from-blue-500 to-blue-600 dark:from-blue-700 dark:to-blue-800 text-white flex items-center justify-between">
+        <h3 className="font-semibold text-sm">通知 ({unreadCount})</h3>
+        <div className="flex gap-2">
+          {unreadCount > 0 && (
+            <button
+              onClick={markAllAsRead}
+              className="text-xs px-2 py-1 rounded bg-white/20 hover:bg-white/30 transition-colors"
+            >
+              すべて既読
+            </button>
+          )}
+          {notifications.length > 0 && (
+            <button
+              onClick={() => {
+                if (confirm("すべての通知を削除しますか？")) {
+                  clearAll();
+                }
+              }}
+              className="text-xs px-2 py-1 rounded bg-white/20 hover:bg-white/30 transition-colors"
+            >
+              すべて削除
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 通知リスト */}
+      <div className="max-h-[520px] overflow-y-auto">
+        {notifications.length === 0 ? (
+          <div className="p-8 text-center text-gray-500 dark:text-slate-400">
+            <svg
+              className="w-16 h-16 mx-auto mb-3 opacity-30"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={1.5}
+                d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
+              />
+            </svg>
+            <p className="text-sm">通知はありません</p>
+          </div>
+        ) : (
+          notifications.map((notification) => (
+            <NotificationItem
+              key={notification.id}
+              notification={notification}
+              onRead={() => markAsRead(notification.id)}
+              onDelete={() => deleteNotification(notification.id)}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}
+
+type NotificationItemProps = {
+  notification: Notification;
+  onRead: () => void;
+  onDelete: () => void;
+};
+
+function NotificationItem({ notification, onRead, onDelete }: NotificationItemProps) {
+  const { type, taskTitle, site, deadline, progress, read } = notification;
+
+  const typeConfig = {
+    deadline_today: {
+      icon: "🔔",
+      label: "期限が今日",
+      color: "text-blue-600 dark:text-blue-400",
+      bgColor: "bg-blue-50 dark:bg-blue-900/20",
+    },
+    deadline_tomorrow: {
+      icon: "⚠️",
+      label: "明日が期限",
+      color: "text-amber-600 dark:text-amber-400",
+      bgColor: "bg-amber-50 dark:bg-amber-900/20",
+    },
+    deadline_overdue: {
+      icon: "🚨",
+      label: "期限超過",
+      color: "text-red-600 dark:text-red-400",
+      bgColor: "bg-red-50 dark:bg-red-900/20",
+    },
+  };
+
+  const config = typeConfig[type];
+
+  return (
+    <div
+      className={`px-4 py-3 border-b border-gray-100 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/50 transition-colors cursor-pointer ${
+        !read ? "bg-blue-50/30 dark:bg-blue-900/10" : ""
+      }`}
+      onClick={() => {
+        if (!read) onRead();
+        // タスク詳細へ遷移（将来的にはルーティングと連携）
+        window.location.hash = `#/tasks?id=${notification.taskId}`;
+      }}
+    >
+      <div className="flex items-start gap-3">
+        <div className={`text-2xl ${config.bgColor} rounded-full p-2 leading-none`}>
+          {config.icon}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className={`text-xs font-semibold ${config.color}`}>{config.label}</span>
+            {!read && (
+              <span className="w-2 h-2 bg-blue-500 rounded-full"></span>
+            )}
+          </div>
+          <h4 className="text-sm font-medium text-gray-900 dark:text-white truncate">
+            {taskTitle}
+          </h4>
+          {site && (
+            <p className="text-xs text-gray-600 dark:text-slate-400 mt-0.5">{site}</p>
+          )}
+          <div className="flex items-center gap-3 mt-2 text-xs text-gray-500 dark:text-slate-400">
+            <span>期限: {deadline.split("T")[0]}</span>
+            <span>進捗: {progress}%</span>
+          </div>
+        </div>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          className="p-1 text-gray-400 hover:text-red-500 dark:hover:text-red-400 transition-colors"
+          aria-label="削除"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/notifications/browserNotification.ts
+++ b/frontend/src/features/notifications/browserNotification.ts
@@ -1,0 +1,66 @@
+// features/notifications/browserNotification.ts - ブラウザ通知ヘルパー
+import type { Notification } from "../../types";
+
+/** ブラウザ通知の許可を取得 */
+export async function requestNotificationPermission(): Promise<boolean> {
+  if (!("Notification" in window)) {
+    console.warn("このブラウザは通知をサポートしていません");
+    return false;
+  }
+
+  if (Notification.permission === "granted") {
+    return true;
+  }
+
+  if (Notification.permission !== "denied") {
+    const permission = await Notification.requestPermission();
+    return permission === "granted";
+  }
+
+  return false;
+}
+
+/** ブラウザ通知を送信 */
+export function sendBrowserNotification(notification: Notification): void {
+  if (!("Notification" in window) || Notification.permission !== "granted") {
+    return;
+  }
+
+  const { type, taskTitle, site, deadline, progress } = notification;
+
+  let title = "";
+  let body = "";
+  let icon = "/icon.svg";
+
+  switch (type) {
+    case "deadline_today":
+      title = "🔔 期限が今日のタスクがあります";
+      body = `${site ? `${site} - ` : ""}${taskTitle}\n進捗: ${progress}%`;
+      break;
+    case "deadline_tomorrow":
+      title = "⚠️ 明日期限のタスクがあります";
+      body = `${site ? `${site} - ` : ""}${taskTitle}\n進捗: ${progress}%`;
+      break;
+    case "deadline_overdue":
+      title = "🚨 期限超過のタスクがあります";
+      body = `${site ? `${site} - ` : ""}${taskTitle}\n期限: ${deadline}\n進捗: ${progress}%`;
+      icon = "/icon-alert.svg";
+      break;
+  }
+
+  const browserNotification = new Notification(title, {
+    body,
+    icon,
+    badge: "/badge.png",
+    tag: `task-${notification.taskId}`,
+    requireInteraction: type === "deadline_overdue", // 期限超過は手動で閉じる必要がある
+    silent: false,
+  });
+
+  browserNotification.onclick = () => {
+    window.focus();
+    // タスク詳細へ遷移（将来的にはルーティングと連携）
+    window.location.hash = `#/tasks?id=${notification.taskId}`;
+    browserNotification.close();
+  };
+}

--- a/frontend/src/features/notifications/notificationUtils.ts
+++ b/frontend/src/features/notifications/notificationUtils.ts
@@ -1,0 +1,84 @@
+// features/notifications/notificationUtils.ts - 期限チェックロジック
+import type { Task, Notification, NotificationType } from "../../types";
+
+/** 日付を YYYY-MM-DD 形式に変換 */
+function formatDate(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+/** タスクの期限から通知タイプを判定 */
+export function getNotificationType(
+  task: Task
+): NotificationType | null {
+  if (!task.deadline || task.status === "completed") {
+    return null;
+  }
+
+  const today = formatDate(new Date());
+  const tomorrow = formatDate(new Date(Date.now() + 24 * 60 * 60 * 1000));
+  const deadline = task.deadline.split("T")[0];
+
+  if (deadline < today) {
+    return "deadline_overdue";
+  }
+  if (deadline === today) {
+    return "deadline_today";
+  }
+  if (deadline === tomorrow) {
+    return "deadline_tomorrow";
+  }
+
+  return null;
+}
+
+/** タスクから通知を生成 */
+export function createNotification(task: Task): Notification | null {
+  const type = getNotificationType(task);
+  if (!type) {
+    return null;
+  }
+
+  return {
+    id: `${type}-${task.id}-${Date.now()}`,
+    type,
+    taskId: task.id,
+    taskTitle: task.title,
+    site: task.site,
+    deadline: task.deadline!,
+    progress: task.progress,
+    createdAt: new Date().toISOString(),
+    read: false,
+  };
+}
+
+/** タスクリストから通知を生成 */
+export function generateNotifications(tasks: Task[]): Notification[] {
+  const notifications: Notification[] = [];
+
+  for (const task of tasks) {
+    const notification = createNotification(task);
+    if (notification) {
+      notifications.push(notification);
+    }
+  }
+
+  return notifications;
+}
+
+/** 通知の重複をチェック（同じタスクで同じタイプの通知は1つのみ） */
+export function deduplicateNotifications(
+  notifications: Notification[]
+): Notification[] {
+  const seen = new Set<string>();
+  const unique: Notification[] = [];
+
+  for (const notif of notifications) {
+    const key = `${notif.type}-${notif.taskId}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      unique.push(notif);
+    }
+  }
+
+  return unique;
+}

--- a/frontend/src/features/notifications/useNotifications.tsx
+++ b/frontend/src/features/notifications/useNotifications.tsx
@@ -1,0 +1,210 @@
+// features/notifications/useNotifications.tsx - 通知コンテキストとフック
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useCallback,
+  type ReactNode,
+} from "react";
+import type {
+  Notification,
+  NotificationSettings,
+  Task,
+} from "../../types";
+import { defaultNotificationSettings } from "../../types";
+import { useTasks } from "../tasks/useTasks";
+import { generateNotifications, deduplicateNotifications } from "./notificationUtils";
+import { sendBrowserNotification, requestNotificationPermission } from "./browserNotification";
+
+const STORAGE_KEY_NOTIFICATIONS = "genba_tasks_notifications";
+const STORAGE_KEY_SETTINGS = "genba_tasks_notification_settings";
+const CHECK_INTERVAL = 5 * 60 * 1000; // 5分ごとにチェック
+
+type NotificationContextType = {
+  notifications: Notification[];
+  unreadCount: number;
+  settings: NotificationSettings;
+  markAsRead: (id: string) => void;
+  markAllAsRead: () => void;
+  deleteNotification: (id: string) => void;
+  clearAll: () => void;
+  updateSettings: (settings: Partial<NotificationSettings>) => void;
+  requestBrowserPermission: () => Promise<boolean>;
+  checkForNewNotifications: () => void;
+};
+
+const NotificationContext = createContext<NotificationContextType | null>(null);
+
+export function NotificationProvider({ children }: { children: ReactNode }) {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [settings, setSettings] = useState<NotificationSettings>(defaultNotificationSettings);
+  const { data: tasksData } = useTasks({});
+
+  // localStorageから通知を読み込み
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY_NOTIFICATIONS);
+      if (stored) {
+        setNotifications(JSON.parse(stored));
+      }
+    } catch (error) {
+      console.error("通知の読み込みに失敗しました:", error);
+    }
+  }, []);
+
+  // localStorageから設定を読み込み
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY_SETTINGS);
+      if (stored) {
+        setSettings({ ...defaultNotificationSettings, ...JSON.parse(stored) });
+      }
+    } catch (error) {
+      console.error("通知設定の読み込みに失敗しました:", error);
+    }
+  }, []);
+
+  // localStorageに通知を保存
+  useEffect(() => {
+    try {
+      // 最新20件のみ保存
+      const toSave = notifications.slice(0, 20);
+      localStorage.setItem(STORAGE_KEY_NOTIFICATIONS, JSON.stringify(toSave));
+    } catch (error) {
+      console.error("通知の保存に失敗しました:", error);
+    }
+  }, [notifications]);
+
+  // 新しい通知をチェック
+  const checkForNewNotifications = useCallback(() => {
+    if (!settings.enabled || !tasksData) {
+      return;
+    }
+
+    const tasks: Task[] = tasksData.tasks || [];
+    const newNotifications = generateNotifications(tasks);
+
+    // 設定に基づいてフィルタリング
+    const filtered = newNotifications.filter((notif) => {
+      switch (notif.type) {
+        case "deadline_today":
+          return settings.deadlineToday;
+        case "deadline_tomorrow":
+          return settings.deadlineTomorrow;
+        case "deadline_overdue":
+          return settings.deadlineOverdue;
+        default:
+          return false;
+      }
+    });
+
+    // 既存の通知と重複しないものだけ追加
+    setNotifications((prev) => {
+      const existingKeys = new Set(
+        prev.map((n) => `${n.type}-${n.taskId}`)
+      );
+      const toAdd = filtered.filter(
+        (n) => !existingKeys.has(`${n.type}-${n.taskId}`)
+      );
+
+      if (toAdd.length === 0) {
+        return prev;
+      }
+
+      // ブラウザ通知を送信
+      if (settings.browserNotifications) {
+        toAdd.forEach((notif) => {
+          sendBrowserNotification(notif);
+        });
+      }
+
+      return deduplicateNotifications([...toAdd, ...prev]);
+    });
+  }, [settings, tasksData]);
+
+  // 定期的にチェック
+  useEffect(() => {
+    if (!settings.enabled) {
+      return;
+    }
+
+    checkForNewNotifications();
+    const intervalId = setInterval(checkForNewNotifications, CHECK_INTERVAL);
+
+    return () => clearInterval(intervalId);
+  }, [settings.enabled, checkForNewNotifications]);
+
+  // 未読数を計算
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  const markAsRead = useCallback((id: string) => {
+    setNotifications((prev) =>
+      prev.map((n) => (n.id === id ? { ...n, read: true } : n))
+    );
+  }, []);
+
+  const markAllAsRead = useCallback(() => {
+    setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+  }, []);
+
+  const deleteNotification = useCallback((id: string) => {
+    setNotifications((prev) => prev.filter((n) => n.id !== id));
+  }, []);
+
+  const clearAll = useCallback(() => {
+    setNotifications([]);
+  }, []);
+
+  const updateSettings = useCallback(
+    (newSettings: Partial<NotificationSettings>) => {
+      setSettings((prev) => {
+        const updated = { ...prev, ...newSettings };
+        try {
+          localStorage.setItem(STORAGE_KEY_SETTINGS, JSON.stringify(updated));
+        } catch (error) {
+          console.error("通知設定の保存に失敗しました:", error);
+        }
+        return updated;
+      });
+    },
+    []
+  );
+
+  const requestBrowserPermission = useCallback(async () => {
+    const granted = await requestNotificationPermission();
+    if (granted) {
+      updateSettings({ browserNotifications: true });
+    }
+    return granted;
+  }, [updateSettings]);
+
+  const value: NotificationContextType = {
+    notifications,
+    unreadCount,
+    settings,
+    markAsRead,
+    markAllAsRead,
+    deleteNotification,
+    clearAll,
+    updateSettings,
+    requestBrowserPermission,
+    checkForNewNotifications,
+  };
+
+  return (
+    <NotificationContext.Provider value={value}>
+      {children}
+    </NotificationContext.Provider>
+  );
+}
+
+export function useNotifications() {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error(
+      "useNotifications must be used within NotificationProvider"
+    );
+  }
+  return context;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import { TaskDrawerProvider } from "./features/drawer/useTaskDrawer";
 import { ToastProvider } from "./components/ToastProvider";
 import { SidebarProvider } from "./contexts/SidebarContext";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { NotificationProvider } from "./features/notifications/useNotifications";
 
 // Sentry初期化
 if (import.meta.env.VITE_SENTRY_DSN) {
@@ -68,13 +69,15 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <ErrorBoundary>
       <QueryClientProvider client={queryClient}>
         <AuthProvider>
-          <SidebarProvider>
-            <TaskDrawerProvider>
-              <ToastProvider>
-                <AppRouter />
-              </ToastProvider>
-            </TaskDrawerProvider>
-          </SidebarProvider>
+          <NotificationProvider>
+            <SidebarProvider>
+              <TaskDrawerProvider>
+                <ToastProvider>
+                  <AppRouter />
+                </ToastProvider>
+              </TaskDrawerProvider>
+            </SidebarProvider>
+          </NotificationProvider>
         </AuthProvider>
       </QueryClientProvider>
     </ErrorBoundary>

--- a/frontend/src/pages/NotificationSettings.tsx
+++ b/frontend/src/pages/NotificationSettings.tsx
@@ -1,0 +1,169 @@
+// pages/NotificationSettings.tsx - 通知設定画面
+import { Link } from "react-router-dom";
+import { useNotifications } from "../features/notifications/useNotifications";
+
+export default function NotificationSettings() {
+  const { settings, updateSettings, requestBrowserPermission } = useNotifications();
+
+  const handleBrowserNotificationToggle = async () => {
+    if (!settings.browserNotifications) {
+      const granted = await requestBrowserPermission();
+      if (!granted) {
+        alert(
+          "ブラウザ通知が許可されていません。ブラウザの設定から通知を許可してください。"
+        );
+      }
+    } else {
+      updateSettings({ browserNotifications: false });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-slate-900 pt-14">
+      <div className="max-w-4xl mx-auto p-6">
+        {/* ヘッダー */}
+        <div className="mb-6">
+          <Link
+            to="/tasks"
+            className="text-sm text-blue-600 dark:text-blue-400 hover:underline inline-flex items-center gap-1 mb-4"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            タスク一覧に戻る
+          </Link>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">通知設定</h1>
+          <p className="text-gray-600 dark:text-slate-400 mt-2">
+            期限が近いタスクや期限超過タスクの通知設定を管理します。
+          </p>
+        </div>
+
+        {/* 通知全体のON/OFF */}
+        <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 mb-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">通知機能</h2>
+              <p className="text-sm text-gray-600 dark:text-slate-400 mt-1">
+                タスクの期限通知を有効化します
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={settings.enabled}
+                onChange={(e) => updateSettings({ enabled: e.target.checked })}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-300 dark:bg-slate-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+            </label>
+          </div>
+        </div>
+
+        {/* ブラウザ通知 */}
+        <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6 mb-6">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+                ブラウザ通知
+              </h2>
+              <p className="text-sm text-gray-600 dark:text-slate-400 mt-1">
+                ブラウザのデスクトップ通知を有効化します
+              </p>
+            </div>
+            <label className="relative inline-flex items-center cursor-pointer">
+              <input
+                type="checkbox"
+                checked={settings.browserNotifications}
+                onChange={handleBrowserNotificationToggle}
+                disabled={!settings.enabled}
+                className="sr-only peer"
+              />
+              <div className="w-11 h-6 bg-gray-300 dark:bg-slate-600 rounded-full peer peer-disabled:opacity-50 peer-disabled:cursor-not-allowed peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+            </label>
+          </div>
+          {settings.browserNotifications && (
+            <div className="text-sm text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/20 p-3 rounded">
+              ✓ ブラウザ通知が許可されています
+            </div>
+          )}
+        </div>
+
+        {/* 通知タイミング */}
+        <div className="bg-white dark:bg-slate-800 rounded-lg shadow-sm border border-gray-200 dark:border-slate-700 p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+            通知タイミング
+          </h2>
+          <div className="space-y-4">
+            {/* 期限当日 */}
+            <label className="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/50 cursor-pointer transition-colors">
+              <div>
+                <div className="font-medium text-gray-900 dark:text-white">期限が今日</div>
+                <div className="text-sm text-gray-600 dark:text-slate-400">
+                  期限が今日のタスクを通知します
+                </div>
+              </div>
+              <input
+                type="checkbox"
+                checked={settings.deadlineToday}
+                onChange={(e) => updateSettings({ deadlineToday: e.target.checked })}
+                disabled={!settings.enabled}
+                className="w-5 h-5 accent-blue-600 disabled:opacity-50"
+              />
+            </label>
+
+            {/* 期限1日前 */}
+            <label className="flex items-center justify-between p-4 rounded-lg border border-gray-200 dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-700/50 cursor-pointer transition-colors">
+              <div>
+                <div className="font-medium text-gray-900 dark:text-white">明日が期限</div>
+                <div className="text-sm text-gray-600 dark:text-slate-400">
+                  明日が期限のタスクを通知します
+                </div>
+              </div>
+              <input
+                type="checkbox"
+                checked={settings.deadlineTomorrow}
+                onChange={(e) => updateSettings({ deadlineTomorrow: e.target.checked })}
+                disabled={!settings.enabled}
+                className="w-5 h-5 accent-blue-600 disabled:opacity-50"
+              />
+            </label>
+
+            {/* 期限超過 */}
+            <label className="flex items-center justify-between p-4 rounded-lg border border-red-200 dark:border-red-900/50 hover:bg-red-50 dark:hover:bg-red-900/20 cursor-pointer transition-colors">
+              <div>
+                <div className="font-medium text-gray-900 dark:text-white">期限超過</div>
+                <div className="text-sm text-gray-600 dark:text-slate-400">
+                  期限を過ぎたタスクを通知します（重要）
+                </div>
+              </div>
+              <input
+                type="checkbox"
+                checked={settings.deadlineOverdue}
+                onChange={(e) => updateSettings({ deadlineOverdue: e.target.checked })}
+                disabled={!settings.enabled}
+                className="w-5 h-5 accent-red-600 disabled:opacity-50"
+              />
+            </label>
+          </div>
+        </div>
+
+        {/* 説明 */}
+        <div className="mt-6 p-4 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-900/50 rounded-lg">
+          <h3 className="text-sm font-semibold text-blue-900 dark:text-blue-300 mb-2">
+            💡 通知について
+          </h3>
+          <ul className="text-sm text-blue-800 dark:text-blue-200 space-y-1">
+            <li>• 通知は5分ごとに自動でチェックされます</li>
+            <li>• ブラウザを開いている間のみ通知が届きます</li>
+            <li>• 同じタスクの重複通知は自動で除外されます</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router/AppRouter.tsx
+++ b/frontend/src/router/AppRouter.tsx
@@ -12,6 +12,7 @@ import Help from "../pages/Help";
 import Home from "../pages/Home";
 import CalendarPage from "../pages/CalendarPage";
 import GalleryPage from "../pages/GalleryPage";
+import NotificationSettings from "../pages/NotificationSettings";
 
 export const AppRouter = () => {
   return (
@@ -33,6 +34,7 @@ export const AppRouter = () => {
             <Route path="/calendar" element={<CalendarPage />} />
             <Route path="/gallery" element={<GalleryPage />} />
             <Route path="/account" element={<Account />} />
+            <Route path="/notifications" element={<NotificationSettings />} />
             <Route path="/help" element={<Help />} />
             {/* 保護領域内のフォールバックは /tasks */}
             <Route path="*" element={<Navigate to="/tasks" replace />} />

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -7,3 +7,4 @@ export * from "./filter";
 export * from "./api";
 export * from "./react";
 export * from "./attachment";
+export * from "./notification";

--- a/frontend/src/types/notification.ts
+++ b/frontend/src/types/notification.ts
@@ -1,0 +1,39 @@
+// types/notification.ts - 通知機能の型定義
+import type { ISODateString } from "./common";
+
+/** 通知の種類 */
+export type NotificationType =
+  | "deadline_today" // 期限が今日
+  | "deadline_tomorrow" // 期限が明日
+  | "deadline_overdue"; // 期限超過
+
+/** 通知データ */
+export type Notification = {
+  id: string; // UUID
+  type: NotificationType;
+  taskId: number;
+  taskTitle: string;
+  site: string | null;
+  deadline: ISODateString;
+  progress: number; // 0..100
+  createdAt: ISODateString;
+  read: boolean;
+};
+
+/** 通知設定 */
+export type NotificationSettings = {
+  enabled: boolean; // 通知機能全体のON/OFF
+  browserNotifications: boolean; // ブラウザ通知の許可
+  deadlineToday: boolean; // 期限当日の通知
+  deadlineTomorrow: boolean; // 期限1日前の通知
+  deadlineOverdue: boolean; // 期限超過の通知
+};
+
+/** デフォルトの通知設定 */
+export const defaultNotificationSettings: NotificationSettings = {
+  enabled: true,
+  browserNotifications: false,
+  deadlineToday: true,
+  deadlineTomorrow: true,
+  deadlineOverdue: true,
+};


### PR DESCRIPTION
## 概要
期限が近いタスクや期限超過タスクをユーザーに通知する機能を実装しました。

## 実装内容

### 1. アプリ内通知センター
- ヘッダーにベルアイコンを追加（未読件数バッジ付き）
- 通知パネルで通知一覧を表示
- 通知の既読/削除機能
- 最新20件をlocalStorageに保存

### 2. ブラウザ通知
- Web Push APIを使用したデスクトップ通知
- 通知許可のリクエスト機能
- 通知クリックでタスク詳細へ遷移

### 3. 通知トリガー
- **期限が今日**: 今日期限のタスクを通知
- **明日が期限**: 明日期限のタスクを通知
- **期限超過**: 期限を過ぎたタスクを通知
- アプリ起動時のチェック
- 5分ごとの自動チェック

### 4. 通知設定画面
- `/notifications` ルートを追加
- 通知ON/OFF切り替え
- ブラウザ通知の許可管理
- 通知タイミングの個別設定

### 5. 技術仕様
- React Context APIで状態管理
- localStorageで設定と通知を永続化
- Web Push APIでブラウザ通知
- 重複通知の自動除外
- ダークモード対応

## ファイル構成
```
frontend/src/
├─ types/
│  └─ notification.ts                # 通知の型定義
├─ features/notifications/
│  ├─ useNotifications.tsx           # Context & Provider
│  ├─ NotificationCenter.tsx         # 通知パネルUI
│  ├─ notificationUtils.ts           # 期限チェックロジック
│  └─ browserNotification.ts         # ブラウザ通知ヘルパー
├─ pages/
│  └─ NotificationSettings.tsx       # 設定画面
├─ components/
│  ├─ Header.tsx                     # ベルアイコン追加
│  └─ Sidebar.tsx                    # 通知設定リンク追加
├─ router/
│  └─ AppRouter.tsx                  # ルーティング追加
└─ main.tsx                          # Provider追加
```

## 主な機能
- [x] アプリ内通知センター
- [x] ブラウザ通知（デスクトップ通知）
- [x] 通知の既読/未読管理
- [x] 通知の個別削除・全削除
- [x] 細かい通知設定
- [x] 5分ごとの自動チェック
- [x] ダークモード対応
- [x] サイドバーに通知設定リンク

## テスト計画
- [ ] 期限が近いタスクを作成して通知が表示されることを確認
- [ ] ブラウザ通知の許可リクエストが機能することを確認
- [ ] 通知設定の変更が反映されることを確認
- [ ] 通知パネルの既読/削除が機能することを確認
- [ ] ダークモードで適切に表示されることを確認

## スクリーンショット
実装後、ヘッダーのベルアイコンから通知を確認できます。
通知設定は `/notifications` から行えます。

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)