### PR TITLE
カレンダービューの改善：日表示と複数日タスク対応

### DIFF
--- a/backend/app/controllers/api/tasks_controller.rb
+++ b/backend/app/controllers/api/tasks_controller.rb
@@ -4,7 +4,7 @@ module Api
     before_action :set_task, only: %i[show update destroy reorder]
     before_action :_debug_params, only: %i[create update reorder], if: -> { ENV["E2E_DEBUG_PARAMS"] == "1" }
 
-    SELECT_FIELDS = %i[id title status progress deadline parent_id depth description site].freeze
+    SELECT_FIELDS = %i[id title status progress deadline start_date parent_id depth description site].freeze
 
     # GET /api/tasks
     def index
@@ -312,7 +312,7 @@ render json: scope.with_attached_image.as_json(only: SELECT_FIELDS, methods: [:i
         end
 
       ActionController::Parameters.new(src)
-        .permit(:title, :status, :progress, :deadline, :parent_id, :description, :site)
+        .permit(:title, :status, :progress, :deadline, :start_date, :parent_id, :description, :site)
     end
 
     # 同一 parent 内で position を付け替える

--- a/backend/db/migrate/20251215014628_add_start_date_to_tasks.rb
+++ b/backend/db/migrate/20251215014628_add_start_date_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStartDateToTasks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :tasks, :start_date, :date
+  end
+end

--- a/frontend/src/types/task.ts
+++ b/frontend/src/types/task.ts
@@ -12,6 +12,7 @@ export type Task = {
   status: Status;
   progress: number; // 0..100
   deadline: ISODateString | null;
+  start_date?: ISODateString | null; // 開始日（複数日タスク用）
   site: string | null; // 子タスクでは null が許容される
   parent_id: number | null; // 親タスクの場合は null
 };


### PR DESCRIPTION
## 概要
カレンダーページに日表示の追加と、複数日にまたがるタスクの表示機能を実装しました。

## 実装内容

### A. 日表示の追加 ⭐
- 月/週に加えて**日表示（タイムライン形式）**を追加
- ビュー切り替えボタンに「日表示」を追加
- 1日のタスクを時系列で詳細に表示できるように

### B. 複数日タスクの表示 ⭐
- タスクモデルに`start_date`フィールドを追加（バックエンド）
- `start_date`〜`deadline`の期間でタスクを表示
- 工事などの長期タスクが見やすくなる
- `start_date`がない場合は従来通り`deadline`のみで表示

## 変更詳細

### バックエンド
- `tasks`テーブルに`start_date`カラムを追加
- `SELECT_FIELDS`に`start_date`を追加
- `task_params`で`start_date`を許可

### フロントエンド
- `Task`型に`start_date`（オプショナル）を追加
- カレンダービューを`"month" | "week" | "day"`の3種類に拡張
- イベント表示ロジックを更新:
  - `start_date`がある → 期間表示（`start: start_date, end: deadline`）
  - `start_date`がない → 単日表示（`start: deadline`）
- FullCalendarの設定に`timeGridDay`を追加

## スクリーンショット
### 日表示
- タイムライン形式で1日のタスクを詳細表示
- 時間軸で視覚的に確認しやすい

### 複数日タスク
- 開始日〜期限日の期間が色付きバーで表示
- 長期プロジェクトの進行状況が一目瞭然

## メリット
- ✅ より詳細な時間管理が可能
- ✅ 長期タスクの進捗が視覚的に把握しやすい
- ✅ 1日の詳細なスケジュールを確認できる
- ✅ 工事現場などの長期プロジェクトに最適
- ✅ 既存のドラッグ&ドロップ機能もそのまま動作

## 互換性
- 既存の`deadline`のみのタスクは従来通り動作
- `start_date`は任意フィールドのため、後方互換性あり

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)