### PR TITLE
feat: キーボードショートカット機能を実装

### DIFF
--- a/frontend/src/components/KeyboardShortcutsHelp.tsx
+++ b/frontend/src/components/KeyboardShortcutsHelp.tsx
@@ -1,0 +1,137 @@
+// components/KeyboardShortcutsHelp.tsx - キーボードショートカット一覧モーダル
+import type { Shortcut } from "../hooks/useKeyboardShortcuts";
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+type ShortcutCategory = {
+  title: string;
+  shortcuts: Array<{
+    keys: string;
+    description: string;
+  }>;
+};
+
+const SHORTCUT_CATEGORIES: ShortcutCategory[] = [
+  {
+    title: "基本操作",
+    shortcuts: [
+      { keys: "F, /", description: "検索ボックスにフォーカス" },
+      { keys: "Esc", description: "モーダル/ドロワーを閉じる" },
+      { keys: "?", description: "このヘルプを表示" },
+      { keys: "N", description: "新規タスクを作成" },
+    ],
+  },
+  {
+    title: "ナビゲーション",
+    shortcuts: [
+      { keys: "G → T", description: "タスク一覧へ移動" },
+      { keys: "G → C", description: "カレンダーへ移動" },
+      { keys: "G → G", description: "ギャラリーへ移動" },
+      { keys: "G → A", description: "アカウント設定へ移動" },
+    ],
+  },
+  {
+    title: "フィルター操作",
+    shortcuts: [
+      { keys: "1", description: "未着手のみ表示" },
+      { keys: "2", description: "進行中のみ表示" },
+      { keys: "3", description: "完了のみ表示" },
+      { keys: "0", description: "フィルターをすべて解除" },
+    ],
+  },
+];
+
+function ShortcutItem({ keys, description }: { keys: string; description: string }) {
+  return (
+    <div className="flex items-center justify-between py-2 px-3 hover:bg-gray-50 dark:hover:bg-gray-700 rounded">
+      <span className="text-sm text-gray-700 dark:text-gray-300">{description}</span>
+      <div className="flex gap-1">
+        {keys.split(",").map((key, i) => (
+          <kbd
+            key={i}
+            className="px-2 py-1 text-xs font-semibold text-gray-800 dark:text-gray-200 bg-gray-100 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded shadow-sm"
+          >
+            {key.trim()}
+          </kbd>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default function KeyboardShortcutsHelp({ isOpen, onClose }: Props) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-2xl w-full mx-4 max-h-[80vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* ヘッダー */}
+        <div className="sticky top-0 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 px-6 py-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-gray-900 dark:text-white flex items-center gap-2">
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"
+              />
+            </svg>
+            キーボードショートカット
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            aria-label="閉じる"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* コンテンツ */}
+        <div className="px-6 py-4">
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+            キーボードショートカットを使用して、より効率的に作業できます。
+          </p>
+
+          <div className="space-y-6">
+            {SHORTCUT_CATEGORIES.map((category) => (
+              <div key={category.title}>
+                <h3 className="text-sm font-semibold text-gray-900 dark:text-white mb-2 uppercase tracking-wide">
+                  {category.title}
+                </h3>
+                <div className="space-y-1">
+                  {category.shortcuts.map((shortcut, i) => (
+                    <ShortcutItem key={i} {...shortcut} />
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* フッター */}
+        <div className="sticky bottom-0 bg-gray-50 dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-6 py-4">
+          <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
+            <kbd className="px-1 py-0.5 text-xs bg-gray-200 dark:bg-gray-700 rounded">Esc</kbd> キーまたは背景をクリックして閉じる
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,10 +1,69 @@
 // src/components/Layout.tsx
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import Header from "./Header";
 import Sidebar from "./Sidebar";
 import { Outlet } from "react-router-dom";
 import TaskDrawer from "../features/drawer/TaskDrawer";
+import KeyboardShortcutsHelp from "./KeyboardShortcutsHelp";
+import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts";
+import { useTaskDrawer } from "../features/drawer/useTaskDrawer";
 
 const Layout = () => {
+  const navigate = useNavigate();
+  const { close: closeDrawer } = useTaskDrawer();
+  const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
+
+  // グローバルショートカット
+  useKeyboardShortcuts([
+    // ヘルプモーダル
+    {
+      key: "?",
+      description: "キーボードショートカット一覧を表示",
+      action: () => setShowShortcutsHelp(true),
+    },
+    // ナビゲーション（G → X）
+    {
+      key: "t",
+      sequence: ["g", "t"],
+      description: "タスク一覧へ移動",
+      action: () => navigate("/tasks"),
+    },
+    {
+      key: "c",
+      sequence: ["g", "c"],
+      description: "カレンダーへ移動",
+      action: () => navigate("/calendar"),
+    },
+    {
+      key: "g",
+      sequence: ["g", "g"],
+      description: "ギャラリーへ移動",
+      action: () => navigate("/gallery"),
+    },
+    {
+      key: "a",
+      sequence: ["g", "a"],
+      description: "アカウント設定へ移動",
+      action: () => navigate("/account"),
+    },
+    // Escでドロワーを閉じる
+    {
+      key: "Escape",
+      description: "ドロワーを閉じる",
+      action: () => closeDrawer(),
+    },
+  ]);
+
+  // Escでヘルプモーダルを閉じる
+  useKeyboardShortcuts([
+    {
+      key: "Escape",
+      description: "ヘルプモーダルを閉じる",
+      action: () => setShowShortcutsHelp(false),
+    },
+  ], showShortcutsHelp);
+
   return (
     <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
       <Header />
@@ -16,6 +75,10 @@ const Layout = () => {
         </main>
       </div>
       <TaskDrawer />
+      <KeyboardShortcutsHelp
+        isOpen={showShortcutsHelp}
+        onClose={() => setShowShortcutsHelp(false)}
+      />
     </div>
   );
 };

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,106 @@
+// hooks/useKeyboardShortcuts.ts - キーボードショートカット管理フック
+import { useEffect, useCallback, useRef } from "react";
+
+export type ShortcutKey = string;
+
+export type Shortcut = {
+  key: ShortcutKey;
+  description: string;
+  action: () => void;
+  /**
+   * 修飾キー（Ctrl/Cmd/Shift/Alt）が必要な場合
+   */
+  ctrl?: boolean;
+  shift?: boolean;
+  alt?: boolean;
+  /**
+   * 連続入力（例: G → T）
+   */
+  sequence?: ShortcutKey[];
+};
+
+/**
+ * キーボードショートカットを登録するフック
+ * @param shortcuts ショートカット設定の配列
+ * @param enabled ショートカットを有効にするかどうか（デフォルト: true）
+ */
+export function useKeyboardShortcuts(
+  shortcuts: Shortcut[],
+  enabled: boolean = true
+) {
+  const sequenceRef = useRef<string[]>([]);
+  const sequenceTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // 入力フィールド内では無効化
+      const target = e.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      const key = e.key.toLowerCase();
+
+      // シーケンスタイムアウトをクリア
+      if (sequenceTimeoutRef.current) {
+        clearTimeout(sequenceTimeoutRef.current);
+      }
+
+      // 現在のシーケンスに追加
+      sequenceRef.current.push(key);
+
+      // 1秒後にシーケンスをリセット
+      sequenceTimeoutRef.current = setTimeout(() => {
+        sequenceRef.current = [];
+      }, 1000);
+
+      // ショートカットをチェック
+      for (const shortcut of shortcuts) {
+        // 修飾キーのチェック
+        if (shortcut.ctrl && !e.ctrlKey && !e.metaKey) continue;
+        if (shortcut.shift && !e.shiftKey) continue;
+        if (shortcut.alt && !e.altKey) continue;
+
+        // シーケンスショートカットの場合
+        if (shortcut.sequence && shortcut.sequence.length > 0) {
+          const expectedSequence = shortcut.sequence.map((k) => k.toLowerCase());
+          const currentSequence = sequenceRef.current.slice(-expectedSequence.length);
+
+          if (
+            currentSequence.length === expectedSequence.length &&
+            currentSequence.every((k, i) => k === expectedSequence[i])
+          ) {
+            e.preventDefault();
+            shortcut.action();
+            sequenceRef.current = [];
+            return;
+          }
+        }
+        // 単一キーショートカットの場合
+        else if (key === shortcut.key.toLowerCase()) {
+          e.preventDefault();
+          shortcut.action();
+          sequenceRef.current = [];
+          return;
+        }
+      }
+    },
+    [shortcuts, enabled]
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      if (sequenceTimeoutRef.current) {
+        clearTimeout(sequenceTimeoutRef.current);
+      }
+    };
+  }, [handleKeyDown]);
+}


### PR DESCRIPTION
## Summary

タスク管理をより効率的に操作できるキーボードショートカット機能を実装しました。

### 主な機能

**基本操作**
- `F` または `/`: 検索ボックスにフォーカス
- `Esc`: モーダル/ドロワーを閉じる
- `?`: キーボードショートカット一覧を表示

**ナビゲーション（シーケンスキー）**
- `G` → `T`: タスク一覧へ移動
- `G` → `C`: カレンダーへ移動
- `G` → `G`: ギャラリーへ移動
- `G` → `A`: アカウント設定へ移動

**フィルター操作（タスクページのみ）**
- `1`: 未着手のみ表示（トグル）
- `2`: 進行中のみ表示（トグル）
- `3`: 完了のみ表示（トグル）
- `0`: フィルターをすべて解除

### 技術実装

- **useKeyboardShortcutsフック**: 再利用可能なカスタムフック
  - 単一キー、修飾キー（Ctrl/Shift/Alt）、シーケンスキーに対応
  - 入力フィールド内では自動無効化
  - 1秒のシーケンスタイムアウト

- **KeyboardShortcutsHelpコンポーネント**: ヘルプモーダル
  - カテゴリー別にショートカット一覧を表示
  - ダークモード対応

- **グローバルとページ固有のショートカット分離**
  - Layout.tsx: 全ページ共通のショートカット
  - TaskList.tsx: タスクページ固有のショートカット

### 変更ファイル

- `frontend/src/hooks/useKeyboardShortcuts.ts` (新規)
- `frontend/src/components/KeyboardShortcutsHelp.tsx` (新規)
- `frontend/src/components/Layout.tsx` (修正)
- `frontend/src/pages/TaskList.tsx` (修正)

## Test plan

- [ ] `?` キーでヘルプモーダルが表示される
- [ ] `Esc` キーでモーダル/ドロワーが閉じる
- [ ] `G` → `T/C/G/A` でそれぞれのページに移動する
- [ ] タスクページで `F` または `/` キーで検索にフォーカスする
- [ ] タスクページで `1/2/3` キーでステータスフィルターが切り替わる
- [ ] タスクページで `0` キーでフィルターが全解除される
- [ ] 入力フィールド内ではショートカットが無効になる
- [ ] ダークモードでヘルプモーダルが正しく表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)