### PR TITLE
進捗写真管理機能を実装

### DIFF
--- a/backend/app/controllers/api/attachments_controller.rb
+++ b/backend/app/controllers/api/attachments_controller.rb
@@ -39,7 +39,7 @@ class Api::AttachmentsController < ApplicationController
   end
 
   def attachment_params
-    params.require(:attachment).permit(:file, :file_type, :title, :description, :category, :display_order)
+    params.require(:attachment).permit(:file, :file_type, :title, :description, :category, :display_order, :photo_tag, :captured_at, :note)
   end
 
   def attachment_json(attachment)
@@ -51,6 +51,9 @@ class Api::AttachmentsController < ApplicationController
       description: attachment.description,
       category: attachment.category,
       display_order: attachment.display_order,
+      photo_tag: attachment.photo_tag,
+      captured_at: attachment.captured_at,
+      note: attachment.note,
       url: attachment.file.attached? ? url_for(attachment.file) : nil,
       thumbnail_url: attachment.image? && attachment.file.attached? ?
         url_for(attachment.file.variant(resize_to_limit: [400, 400])) : nil,

--- a/backend/app/models/attachment.rb
+++ b/backend/app/models/attachment.rb
@@ -2,13 +2,18 @@ class Attachment < ApplicationRecord
   belongs_to :task
   has_one_attached :file
 
+  PHOTO_TAGS = %w[before during after other].freeze
+
   validates :file_type, presence: true, inclusion: { in: %w[photo document] }
   validates :file, presence: true
+  validates :photo_tag, inclusion: { in: PHOTO_TAGS }, allow_nil: true
   validate :file_size_validation
 
   scope :photos, -> { where(file_type: 'photo') }
   scope :documents, -> { where(file_type: 'document') }
   scope :ordered, -> { order(:display_order, :created_at) }
+  scope :by_photo_tag, ->(tag) { where(photo_tag: tag) }
+  scope :tagged_photos, -> { photos.where.not(photo_tag: nil) }
 
   def image?
     file.attached? && file.content_type.start_with?('image/')

--- a/backend/db/migrate/20251218175736_add_photo_fields_to_attachments.rb
+++ b/backend/db/migrate/20251218175736_add_photo_fields_to_attachments.rb
@@ -1,0 +1,7 @@
+class AddPhotoFieldsToAttachments < ActiveRecord::Migration[8.0]
+  def change
+    add_column :attachments, :photo_tag, :string
+    add_column :attachments, :captured_at, :datetime
+    add_column :attachments, :note, :text
+  end
+end

--- a/frontend/src/features/attachments/useUploadPhoto.ts
+++ b/frontend/src/features/attachments/useUploadPhoto.ts
@@ -9,6 +9,9 @@ export interface UploadPhotoInput {
   title?: string;
   description?: string;
   category?: string;
+  photo_tag?: 'before' | 'during' | 'after' | 'other';
+  note?: string;
+  captured_at?: string;
 }
 
 async function uploadPhotoApi(input: UploadPhotoInput): Promise<Attachment> {
@@ -24,6 +27,15 @@ async function uploadPhotoApi(input: UploadPhotoInput): Promise<Attachment> {
   }
   if (input.category) {
     formData.append("attachment[category]", input.category);
+  }
+  if (input.photo_tag) {
+    formData.append("attachment[photo_tag]", input.photo_tag);
+  }
+  if (input.note) {
+    formData.append("attachment[note]", input.note);
+  }
+  if (input.captured_at) {
+    formData.append("attachment[captured_at]", input.captured_at);
   }
 
   const { data } = await api.post<Attachment>(

--- a/frontend/src/types/attachment.ts
+++ b/frontend/src/types/attachment.ts
@@ -9,6 +9,9 @@ export interface Attachment {
   description: string | null;
   category: string | null;
   display_order: number;
+  photo_tag?: 'before' | 'during' | 'after' | 'other' | null;
+  captured_at?: string | null;
+  note?: string | null;
   url: string | null;
   thumbnail_url: string | null;
   content_type: string | null;
@@ -24,6 +27,9 @@ export interface CreateAttachmentPayload {
   description?: string;
   category?: string;
   display_order?: number;
+  photo_tag?: 'before' | 'during' | 'after' | 'other';
+  captured_at?: string;
+  note?: string;
 }
 
 export interface GalleryFilters {


### PR DESCRIPTION
## 概要
タスクごとに複数枚の写真を添付し、施工前・施工中・施工後などのタグで分類できる機能を実装しました。

Closes #262

## 変更内容

### Backend
- attachmentsテーブルに以下のカラムを追加
  - `photo_tag`: 工程区分 (before/during/after/other)
  - `captured_at`: 撮影日時
  - `note`: メモ
- Attachmentモデルにバリデーションとスコープを追加
- AttachmentsControllerのパラメータとJSONレスポンスに新フィールドを追加

### Frontend
- PhotoUploaderに工程区分選択、撮影日時、メモの入力フィールドを追加
- PhotoGalleryをリスト表示に変更し、タグ別にグループ化して表示
- 写真枚数の制限を撤廃
- TypeScript型定義を更新

## 設計方針
- サムネイル表示なし（画面のタスク表示数を優先）
- 写真枚数制限なし
- シンプルなリスト表示
- タグによる分類管理

## スクリーンショット
（タスク詳細ドロワーで写真をタグ別に表示）

## テスト
- [ ] 写真アップロード時に工程区分を選択できる
- [ ] 撮影日時とメモを入力できる
- [ ] アップロードした写真がタグ別にグループ化されて表示される
- [ ] 写真をクリックすると拡大表示される
- [ ] 写真を削除できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)