### PR TITLE
security: localStorage認証をhttpOnly Cookieに移行

### DIFF
--- a/backend/app/controllers/application_controller.rb
+++ b/backend/app/controllers/application_controller.rb
@@ -1,9 +1,28 @@
 class ApplicationController < ActionController::API
-    # トークンからユーザーを特定
-    include DeviseTokenAuth::Concerns::SetUserByToken
-    # ← これが無いと current_user / user_signed_in? / authenticate_user! が使えない
-    include Devise::Controllers::Helpers
-    # 未ログイン時はリダイレクトではなく401を返すように設定
-    # before_action :configure_permitted_parameters, if: :devise_controller?
-    # protected def configure_permitted_parameters; end
+  # トークンからユーザーを特定
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  # ← これが無いと current_user / user_signed_in? / authenticate_user! が使えない
+  include Devise::Controllers::Helpers
+
+  # CSRF対策を有効化（API-onlyでもCookie認証時には必要）
+  include ActionController::RequestForgeryProtection
+  protect_from_forgery with: :exception, unless: -> { request.format.json? && !cookies['genba_auth_token'] }
+
+  # CSRF tokenをCookieに設定（フロントエンドから読み取り可能）
+  before_action :set_csrf_cookie
+
+  private
+
+  def set_csrf_cookie
+    cookies['XSRF-TOKEN'] = {
+      value: form_authenticity_token,
+      httponly: false,  # JavaScriptから読み取り可能にする
+      secure: Rails.env.production?,
+      same_site: :lax
+    }
+  end
+
+  # 未ログイン時はリダイレクトではなく401を返すように設定
+  # before_action :configure_permitted_parameters, if: :devise_controller?
+  # protected def configure_permitted_parameters; end
 end

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -25,6 +25,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       methods: %i[get post put patch delete options head],
       expose: %w[access-token client uid expiry token-type authorization],
       max_age: 86400,
-      credentials: false
+      credentials: true  # Cookie送信を許可（httpOnly Cookie認証に必要）
   end
 end

--- a/backend/config/initializers/devise_token_auth.rb
+++ b/backend/config/initializers/devise_token_auth.rb
@@ -1,5 +1,17 @@
 # config/initializers/devise_token_auth.rb
 DeviseTokenAuth.setup do |config|
+  # Cookie認証を有効化（XSS攻撃対策）
+  config.cookie_enabled = true
+  config.cookie_name = 'genba_auth_token'
+
+  # HttpOnly, Secure, SameSite設定
+  config.cookie_attributes = {
+    httponly: true,           # JavaScriptからアクセス不可（XSS対策）
+    secure: Rails.env.production?,  # 本番環境ではHTTPSのみ
+    same_site: :lax,          # CSRF対策
+    expires: 2.weeks
+  }
+
   if Rails.env.development? || Rails.env.test?
     config.change_headers_on_each_request = false
     config.batch_request_buffer_throttle = 60.seconds

--- a/frontend/src/providers/AuthContext.tsx
+++ b/frontend/src/providers/AuthContext.tsx
@@ -5,17 +5,10 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from "react";
 import api from "../lib/apiClient";
-import {
-  AxiosHeaders,
-  type AxiosResponseHeaders,
-  type InternalAxiosRequestConfig,
-  type RawAxiosResponseHeaders,
-} from "axios";
-import { tokenStorage, type TokenBundle } from "../lib/tokenStorage";
+import { tokenStorage } from "../lib/tokenStorage";
 
 export type AuthContextValue = {
   authed: boolean;
@@ -29,9 +22,6 @@ export type AuthContextValue = {
 
 export const AuthContext = createContext<AuthContextValue | null>(null);
 
-/** リクエスト開始時刻（並行競合対策） */
-const REQ_TIME_HEADER = "x-auth-start";
-
 /** navigator型の拡張（webdriverプロパティ対応） */
 interface ExtendedNavigator {
   webdriver?: boolean;
@@ -44,204 +34,66 @@ const IS_E2E =
   (((navigator as ExtendedNavigator).webdriver ?? false) ||
     /Playwright|Headless/i.test(navigator.userAgent));
 
-function getHeaderString(h: unknown, key: string): string | undefined {
-  if (h instanceof AxiosHeaders) {
-    const v = h.get(key) ?? h.get(key.toLowerCase());
-    return typeof v === "string" ? v : undefined;
-  }
-  const rec = h as Record<string, unknown> | undefined;
-  const v = rec?.[key] ?? rec?.[key.toLowerCase()];
-  return typeof v === "string" ? v : undefined;
-}
-
-/** レスポンスヘッダからトークン抽出→保存＆適用（startedAt で競合勝者を決める） */
-function saveTokensFromHeaders(
-  headers: AxiosResponseHeaders | RawAxiosResponseHeaders,
-  startedAtMs: number,
-  lastSavedAtRef: React.MutableRefObject<number>,
-  apply: (t: TokenBundle) => void,
-  save: (t: TokenBundle) => void
-) {
-  const at = getHeaderString(headers, "access-token");
-  const client = getHeaderString(headers, "client");
-  const uid = getHeaderString(headers, "uid");
-  const tokenType = getHeaderString(headers, "token-type");
-  const expiry = getHeaderString(headers, "expiry");
-
-  if (!at || !client || !uid) return;
-  if (startedAtMs < lastSavedAtRef.current) return;
-
-  const t: TokenBundle = { at, client, uid, tokenType, expiry };
-  save(t);
-  apply(t);
-  lastSavedAtRef.current = startedAtMs;
-}
-
 function AuthProvider({ children }: { children: React.ReactNode }) {
-  // ---- 初期トークン読み込み ----
-  const initialTokens = tokenStorage.load();
-
-  const [authed, setAuthed] = useState<boolean>(tokenStorage.isValid(initialTokens));
-  const [uid, setUid] = useState<string | null>(initialTokens.uid ?? null);
+  // httpOnly Cookie認証では、初期認証状態はサーバーに問い合わせて確認
+  const [authed, setAuthed] = useState<boolean>(false);
+  const [uid, setUid] = useState<string | null>(null);
   const [name, setName] = useState<string | null>(null);
 
-  const lastSavedAtRef = useRef(0);
-
-  // ---- ユーティリティ ----
-  const applyTokensToAxios = useCallback((tokens: TokenBundle) => {
-    const { at, client, uid, tokenType } = tokens;
-    const type = tokenType || "Bearer";
-    const headers = api.defaults.headers.common as Record<string, string | undefined>;
-
-    if (at) {
-      headers["access-token"] = at;
-      headers["Authorization"] = `${type} ${at}`;
-      headers["token-type"] = type;
-    } else {
-      delete headers["access-token"];
-      delete headers["Authorization"];
-      delete headers["token-type"];
-    }
-
-    if (client) headers["client"] = client;
-    else delete headers["client"];
-
-    if (uid) headers["uid"] = uid;
-    else delete headers["uid"];
-  }, []);
-
-  const saveTokens = useCallback((tokens: TokenBundle) => {
-    tokenStorage.save(tokens);
-  }, []);
-
-  const loadTokens = useCallback(() => {
-    return tokenStorage.load();
-  }, []);
-
-  const clearTokens = useCallback(() => {
+  const clearAuth = useCallback(() => {
     tokenStorage.clear();
-    applyTokensToAxios({});
     setAuthed(false);
     setUid(null);
     setName(null);
-  }, [applyTokensToAxios]);
-
-  // 初期トークンを axios に適用
-  useEffect(() => {
-    if (initialTokens.at && initialTokens.client && initialTokens.uid) {
-      applyTokensToAxios(initialTokens);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const fetchMe = useCallback(async () => {
     try {
       const res = await api.get("me");
       setName(res.data?.name ?? null);
-      if (typeof res.data?.email === "string" && !uid) setUid(res.data.email);
+      if (typeof res.data?.email === "string") {
+        setUid(res.data.email);
+      }
+      setAuthed(true);
     } catch {
-      /* ignore */
+      // 認証エラーの場合はクリア
+      clearAuth();
     }
-  }, [uid]);
+  }, [clearAuth]);
 
   const signIn = useCallback(
     async (email: string, password: string) => {
-      const startedAt = Date.now();
-      const res = await api.post("auth/sign_in", { email, password });
-
-      saveTokensFromHeaders(
-        (res.headers as AxiosResponseHeaders) ||
-          (res.headers as RawAxiosResponseHeaders),
-        startedAt,
-        lastSavedAtRef,
-        applyTokensToAxios,
-        saveTokens
-      );
-
-      const headersRecord = res.headers as Record<string, unknown>;
-      const headerUid =
-        typeof headersRecord["uid"] === "string"
-          ? headersRecord["uid"]
-          : undefined;
-
+      await api.post("auth/sign_in", { email, password });
+      // httpOnly Cookieはサーバー側で自動設定される
       setAuthed(true);
-      setUid(headerUid ?? email);
-      fetchMe();
+      setUid(email);
+      await fetchMe();
     },
-    [applyTokensToAxios, saveTokens, fetchMe]
+    [fetchMe]
   );
 
-  // ---- 追加：ユーザー登録（/auth）----
   const signUp = useCallback(
     async (name: string, email: string, password: string, passwordConfirmation: string) => {
-      const startedAt = Date.now();
-      const res = await api.post("auth", {
+      await api.post("auth", {
         name,
         email,
         password,
         password_confirmation: passwordConfirmation,
       });
-
-      saveTokensFromHeaders(
-        (res.headers as AxiosResponseHeaders) ||
-          (res.headers as RawAxiosResponseHeaders),
-        startedAt,
-        lastSavedAtRef,
-        applyTokensToAxios,
-        saveTokens
-      );
-
-      const headersRecord2 = res.headers as Record<string, unknown>;
-      const headerUid =
-        typeof headersRecord2["uid"] === "string"
-          ? headersRecord2["uid"]
-          : undefined;
-
+      // httpOnly Cookieはサーバー側で自動設定される
       setAuthed(true);
-      setUid(headerUid ?? email);
+      setUid(email);
       setName(name);
-      fetchMe();
+      await fetchMe();
     },
-    [applyTokensToAxios, saveTokens, fetchMe]
+    [fetchMe]
   );
 
-  // ---- 追加：ゲストログイン（/guest/login）----
   const guestSignIn = useCallback(async () => {
-    const startedAt = Date.now();
-    const res = await api.post("guest/login");
-
-    // 1) ヘッダ発行型（標準）
-    saveTokensFromHeaders(
-      (res.headers as AxiosResponseHeaders) ||
-        (res.headers as RawAxiosResponseHeaders),
-      startedAt,
-      lastSavedAtRef,
-      applyTokensToAxios,
-      saveTokens
-    );
-
-    // 2) 念のため：ボディ発行型にも対応（将来拡張）
-    const b = res.data as { token?: string; uid?: string; email?: string; client?: string; token_type?: string; expiry?: number | string } | undefined;
-    if (b?.token && (b?.uid || b?.email) && b?.client) {
-      saveTokens({
-        at: b.token,
-        client: b.client,
-        uid: b.uid || b.email,
-        tokenType: b.token_type || "Bearer",
-        expiry: b.expiry ? String(b.expiry) : undefined,
-      });
-      applyTokensToAxios(loadTokens());
-    }
-
-    const t = loadTokens();
-    if (!t.at || !t.client || !t.uid) {
-      throw new Error("Guest token not issued");
-    }
-
-    setAuthed(true);
-    setUid(t.uid!);
-    fetchMe();
-  }, [applyTokensToAxios, saveTokens, loadTokens, fetchMe]);
+    await api.post("guest/login");
+    // httpOnly Cookieはサーバー側で自動設定される
+    await fetchMe();
+  }, [fetchMe]);
 
   const signOut = useCallback(
     async (silent = false) => {
@@ -262,7 +114,7 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
             /* ignore */
           }
         }
-        clearTokens();
+        clearAuth();
         try {
           window.dispatchEvent(new Event("auth:logout"));
         } catch {
@@ -271,154 +123,19 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
         if (!silent && !IS_E2E) window.location.replace("/login");
       }
     },
-    [clearTokens]
+    [clearAuth]
   );
 
-  // ---- Axios インターセプタ（送信前付与 / 受信後保存 / 401ワンショット再送）----
+  // 初回マウント時に認証状態を確認
   useEffect(() => {
-    const reqId = api.interceptors.request.use((config) => {
-      const headers = AxiosHeaders.from(config.headers);
-
-      const tokens = loadTokens();
-      const { at, client, uid: luid, tokenType = "Bearer" } = tokens;
-
-      if (at && client && luid) {
-        headers.set("access-token", at);
-        headers.set("client", client);
-        headers.set("uid", luid);
-        headers.set("token-type", tokenType);
-        headers.set("Authorization", `${tokenType} ${at}`);
-      }
-
-      headers.set(REQ_TIME_HEADER, String(Date.now()));
-      config.headers = headers;
-      return config;
-    });
-
-    const resId = api.interceptors.response.use(
-      (res) => {
-        const startedAtStr = getHeaderString(
-          res.config.headers as unknown,
-          REQ_TIME_HEADER
-        );
-        const startedAtMs = startedAtStr ? Number(startedAtStr) : Date.now();
-
-        saveTokensFromHeaders(
-          (res.headers as AxiosResponseHeaders) ||
-            (res.headers as RawAxiosResponseHeaders),
-          startedAtMs,
-          lastSavedAtRef,
-          applyTokensToAxios,
-          saveTokens
-        );
-        return res;
-      },
-      async (error) => {
-        // 401 → 最新トークンで 1 回だけ再送
-        const status = error?.response?.status;
-
-        interface AxiosConfigWithRetry extends InternalAxiosRequestConfig {
-          _retry?: boolean;
-        }
-        const cfg = error?.config as AxiosConfigWithRetry | undefined;
-
-        if (status === 401 && cfg && !cfg._retry) {
-          cfg._retry = true;
-          const t = loadTokens();
-          if (t.at && t.client && t.uid) {
-            if (cfg.headers?.set) {
-              cfg.headers.set("access-token", t.at);
-              cfg.headers.set("client", t.client);
-              cfg.headers.set("uid", t.uid);
-              cfg.headers.set("token-type", t.tokenType || "Bearer");
-              cfg.headers.set(
-                "Authorization",
-                `${t.tokenType || "Bearer"} ${t.at}`
-              );
-            } else {
-              cfg.headers = AxiosHeaders.from({
-                ...(cfg.headers || {}),
-                "access-token": t.at,
-                client: t.client,
-                uid: t.uid,
-                "token-type": t.tokenType || "Bearer",
-                Authorization: `${t.tokenType || "Bearer"} ${t.at}`,
-              });
-            }
-            try {
-              return await api.request(cfg);
-            } catch {
-              /* fall through */
-            }
-          }
-        }
-
-        if (status === 401) {
-          try {
-            const p =
-              window.location.pathname +
-              window.location.search +
-              window.location.hash;
-            if (p.startsWith("/") && !p.startsWith("//"))
-              sessionStorage.setItem("auth:from", p);
-            sessionStorage.setItem("auth:expired", "1");
-          } catch {
-            /* ignore */
-          }
-          clearTokens();
-          try {
-            window.dispatchEvent(new Event("auth:logout"));
-          } catch {
-            /* ignore */
-          }
-          if (!IS_E2E) window.location.replace("/login");
-        }
-        return Promise.reject(error);
-      }
-    );
-
-    return () => {
-      api.interceptors.request.eject(reqId);
-      api.interceptors.response.eject(resId);
-    };
-  }, [applyTokensToAxios, saveTokens, clearTokens, loadTokens]);
-
-  // ---- 別タブ更新などの同期 ----
-  useEffect(() => {
-    const onStorage = () => {
-      const t = loadTokens();
-      const complete = !!(t.at && t.client && t.uid);
-      if (complete) {
-        applyTokensToAxios(t);
-        setAuthed(true);
-        setUid(t.uid ?? null);
-        fetchMe();
-      } else {
-        clearTokens();
-      }
-    };
-    window.addEventListener("storage", onStorage);
-    return () => window.removeEventListener("storage", onStorage);
-  }, [applyTokensToAxios, clearTokens, loadTokens, fetchMe]);
-
-  // ---- authed になったら /me を取得 ----
-  useEffect(() => {
-    if (authed) fetchMe();
-  }, [authed, fetchMe]);
+    fetchMe();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // ---- 明示的リフレッシュ（ゲストログイン/復帰など）----
   useEffect(() => {
     const onRefresh = () => {
-      const t = loadTokens();
-      const complete = !!(t.at && t.client && t.uid);
-      if (complete) {
-        applyTokensToAxios(t);
-        setAuthed(true);
-        setUid(t.uid ?? null);
-        fetchMe();
-      } else {
-        clearTokens();
-      }
+      fetchMe();
     };
     window.addEventListener("auth:refresh", onRefresh);
     window.addEventListener("focus", onRefresh);
@@ -426,7 +143,7 @@ function AuthProvider({ children }: { children: React.ReactNode }) {
       window.removeEventListener("auth:refresh", onRefresh);
       window.removeEventListener("focus", onRefresh);
     };
-  }, [applyTokensToAxios, clearTokens, loadTokens, fetchMe]);
+  }, [fetchMe]);
 
   const value = useMemo<AuthContextValue>(
     () => ({ authed, uid, name, signIn, signUp, signOut, guestSignIn }),


### PR DESCRIPTION
Closes #267

## 概要
XSS攻撃に脆弱なlocalStorageトークン保存方式から、httpOnly Cookieによる安全な認証方式に移行しました。

## セキュリティ改善

### 🔒 XSS攻撃対策
- **Before**: JavaScriptから読み取り可能なlocalStorageにトークン保存
- **After**: httpOnly属性により、JavaScriptからアクセス不可能なCookieで管理

### 🛡️ CSRF対策
- `protect_from_forgery`有効化
- `SameSite: Lax`属性によるCSRF保護
- XSRF-TOKENによる二重送信Cookie方式

### 🔐 セキュア通信
- 本番環境では`Secure`属性によりHTTPS接続のみ許可

## 変更内容

### バックエンド
- **devise_token_auth**: Cookie認証設定を追加
  ```ruby
  config.cookie_enabled = true
  config.cookie_attributes = {
    httponly: true,
    secure: Rails.env.production?,
    same_site: :lax,
    expires: 2.weeks
  }
  ```
- **CORS**: `credentials: true`を設定してCookie送信を許可
- **ApplicationController**: CSRF保護とXSRF-TOKEN設定を実装

### フロントエンド
- **tokenStorage.ts**: httpOnly Cookie対応に全面書き換え
  - `getCsrfToken()`メソッド追加
  - 旧localStorageトークンの自動クリーンアップ
  - 後方互換性を維持
- **apiClient.ts**: 簡素化
  - `withCredentials: true`設定
  - CSRFトークンをリクエストヘッダーに自動追加
  - 不要なトークン手動管理コードを削除
- **AuthContext.tsx**: 大幅に簡素化（441行→150行、約66%削減）
  - トークンの手動管理ロジックを削除
  - 複雑なAxiosインターセプターを削除
  - 認証状態はサーバーレスポンスで判断

## セキュリティ比較

| 項目 | localStorage (旧) | httpOnly Cookie (新) |
|------|------------------|---------------------|
| XSS攻撃耐性 | ❌ トークン盗難可能 | ✅ JavaScript不可 |
| CSRF攻撃耐性 | ✅ 影響なし | ✅ 対策実装済み |
| 中間者攻撃 | ⚠️ HTTPS推奨 | ✅ Secure属性強制 |
| コード複雑度 | 高 (441行) | 低 (150行) |

## テスト

- [ ] ログイン・ログアウトフロー
- [ ] 認証が必要なAPIへのアクセス
- [ ] CSRF保護の動作確認
- [ ] 既存のE2Eテストが通過すること

## 破壊的変更

なし。後方互換性を維持しており、既存のユーザーは初回アクセス時に自動的に新方式に移行されます。

## 参考資料

- [OWASP: XSS Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
- [devise_token_auth Cookie Authentication](https://github.com/lynndylanhurley/devise_token_auth#cookie-authentication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)