### PR TITLE
chore: 本番環境のデバッグコード（console.log）を削除

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -30,7 +30,6 @@ const Sidebar = () => {
   const currentSite = sp.get("site") ?? "";
 
   const selectSite = (site: string) => {
-    console.log("[Sidebar] selectSite called with:", site);
     const next = new URLSearchParams(sp);
 
     // 他のフィルターパラメータをクリア
@@ -44,8 +43,6 @@ const Sidebar = () => {
     } else {
       next.delete("site");
     }
-
-    console.log("[Sidebar] Navigating to:", next.toString());
 
     // /tasksページ以外にいる場合は、/tasksに遷移する
     if (location.pathname !== "/tasks") {

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -140,12 +140,8 @@ if (DEMO) {
     // ---- 3) タスク一覧／作成 ----
     if (path === "/tasks" && method === "get") {
       // クエリパラメータを取得（axiosのparamsオブジェクトから直接取得）
-      console.log("[DEMO] cfg.params:", cfg.params);
-      console.log("[DEMO] u.searchParams site:", u.searchParams.get("site"));
       const site = cfg.params?.site || u.searchParams.get("site") || undefined;
-      console.log("[DEMO] Fetching tasks with site filter:", site);
       const tasks = demoStore.list({ site });
-      console.log("[DEMO] Filtered tasks count:", tasks.length);
       return ok(tasks);
     }
     if (path === "/tasks" && method === "post") {


### PR DESCRIPTION
Closes #269

## 概要
本番環境に残存していたデバッグ用の`console.log`文を削除しました。

## 削除したログ

### 1. apiClient.ts (DEMO adapter)
**場所**: [frontend/src/lib/apiClient.ts:143-148](frontend/src/lib/apiClient.ts#L143-L148)

削除した4箇所:
```typescript
console.log("[DEMO] cfg.params:", cfg.params);
console.log("[DEMO] u.searchParams site:", u.searchParams.get("site"));
console.log("[DEMO] Fetching tasks with site filter:", site);
console.log("[DEMO] Filtered tasks count:", tasks.length);
```

### 2. Sidebar.tsx
**場所**: [frontend/src/components/Sidebar.tsx:33,48](frontend/src/components/Sidebar.tsx#L33)

削除した2箇所:
```typescript
console.log("[Sidebar] selectSite called with:", site);
console.log("[Sidebar] Navigating to:", next.toString());
```

## 確認事項（問題なし）

### ✅ DnD関連のデバッグログ
以下のファイルは`import.meta.env.DEV`でガードされており、**本番環境では出力されません**:
- `dndContext.tsx`
- `InlineTaskRow.tsx`  
- `InlineDropZone.tsx`
- `InlineTaskTree.tsx`

```typescript
const DBG = import.meta.env.DEV;
const log = (...args: unknown[]) => DBG && console.log(...args);
```

### ✅ 適切なconsole使用
以下は残しています:
- `console.warn`: ブラウザ機能サポートの警告（適切）
- `console.error`: エラーハンドリング用途（適切）

## 改善効果

| 項目 | Before | After |
|------|--------|-------|
| 本番環境のconsole.log | 6箇所 | 0箇所 |
| パフォーマンス | わずかに低下 | 改善 |
| セキュリティ | 情報漏洩リスク | リスク軽減 |
| コンソール | ログで汚染 | クリーン |

## テスト
- [ ] DEMO modeでタスク一覧の表示確認
- [ ] サイト切り替え機能の動作確認
- [ ] ブラウザコンソールに不要なログが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)