### PR TITLE
refactor: コード品質の改善（コンポーネント分割と重複削減）

### DIFF
--- a/frontend/src/features/drawer/TaskChildForm.tsx
+++ b/frontend/src/features/drawer/TaskChildForm.tsx
@@ -1,0 +1,78 @@
+// src/features/drawer/TaskChildForm.tsx
+import { useState } from "react";
+import { useCreateTask } from "../tasks/useCreateTask";
+import { useToast } from "../../components/ToastProvider";
+import { brandIso } from "../../lib/brandIso";
+import { getUserMessage, logError } from "../../lib/errorHandler";
+
+type Props = {
+  taskId: number;
+  onSuccess: () => void;
+};
+
+/**
+ * タスクドロワー内の子タスク作成フォームコンポーネント
+ */
+export default function TaskChildForm({ taskId, onSuccess }: Props) {
+  const { push: toast } = useToast();
+  const [childTitle, setChildTitle] = useState("");
+  const [childDue, setChildDue] = useState<string>(""); // YYYY-MM-DD
+  const { mutateAsync: createTask, isPending: creating } = useCreateTask();
+
+  const handleCreate = async () => {
+    if (!childTitle.trim()) return;
+
+    try {
+      await createTask({
+        title: childTitle.trim(),
+        parentId: taskId,
+        deadline: brandIso(childDue || undefined),
+      });
+      setChildTitle("");
+      setChildDue("");
+      onSuccess();
+    } catch (err: unknown) {
+      logError(err, 'TaskChildForm - Create');
+      const msg = getUserMessage(err);
+      toast(msg || "作成に失敗しました", "error");
+    }
+  };
+
+  const handleKeyDown = async (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && childTitle.trim()) {
+      await handleCreate();
+    }
+  };
+
+  return (
+    <div className="mt-3 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 p-3">
+      <div className="mb-2 text-[13px] text-gray-500 dark:text-gray-400">
+        子タスクを作成
+      </div>
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <input
+          className="input input-bordered flex-1"
+          placeholder="子タスク名（必須）"
+          value={childTitle}
+          onChange={(e) => setChildTitle(e.target.value)}
+          onKeyDown={handleKeyDown}
+          aria-label="子タスク名"
+        />
+        <input
+          type="date"
+          className="input input-bordered w-full sm:w-40"
+          value={childDue}
+          onChange={(e) => setChildDue(e.target.value)}
+          aria-label="期限"
+        />
+        <button
+          className="btn btn-primary w-full sm:w-auto"
+          onClick={handleCreate}
+          disabled={!childTitle.trim() || creating}
+        >
+          作成
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,9 @@
 // hooks/useKeyboardShortcuts.ts - キーボードショートカット管理フック
 import { useEffect, useCallback, useRef } from "react";
 
+/** キーシーケンス入力のリセットまでの時間（ミリ秒） */
+const SEQUENCE_RESET_TIMEOUT_MS = 1000;
+
 export type ShortcutKey = string;
 
 export type Shortcut = {
@@ -55,10 +58,10 @@ export function useKeyboardShortcuts(
       // 現在のシーケンスに追加
       sequenceRef.current.push(key);
 
-      // 1秒後にシーケンスをリセット
+      // シーケンス入力をリセット（連続入力の判定時間経過後）
       sequenceTimeoutRef.current = setTimeout(() => {
         sequenceRef.current = [];
-      }, 1000);
+      }, SEQUENCE_RESET_TIMEOUT_MS);
 
       // ショートカットをチェック
       for (const shortcut of shortcuts) {

--- a/frontend/src/pages/TaskList.tsx
+++ b/frontend/src/pages/TaskList.tsx
@@ -22,91 +22,66 @@ const TaskList: PageComponent = () => {
 
   const [sp, setSp] = useSearchParams();
 
+  /**
+   * ステータスフィルターを切り替えるヘルパー関数
+   * 指定されたステータスが既に選択されている場合は解除、
+   * 選択されていない場合は単独で選択する
+   */
+  const toggleStatusFilter = (targetStatus: Status) => {
+    const currentStatus = sp.getAll("status") as Status[];
+    const next = new URLSearchParams(sp);
+    const statusSet = new Set(currentStatus);
+
+    if (statusSet.has(targetStatus)) {
+      statusSet.delete(targetStatus);
+    } else {
+      statusSet.clear();
+      statusSet.add(targetStatus);
+    }
+
+    next.delete("status");
+    for (const s of statusSet) {
+      next.append("status", s);
+    }
+    setSp(next, { replace: true });
+  };
+
+  /**
+   * 検索ボックスにフォーカスを当てるヘルパー関数
+   */
+  const focusSearchInput = () => {
+    const searchInput = document.querySelector('[data-testid="search-input"]') as HTMLInputElement;
+    searchInput?.focus();
+  };
+
   // Keyboard shortcuts for TaskList page
   useKeyboardShortcuts([
     // Search focus (F or /)
     {
       key: "f",
       description: "検索ボックスにフォーカス",
-      action: () => {
-        const searchInput = document.querySelector('[data-testid="search-input"]') as HTMLInputElement;
-        searchInput?.focus();
-      },
+      action: focusSearchInput,
     },
     {
       key: "/",
       description: "検索ボックスにフォーカス",
-      action: () => {
-        const searchInput = document.querySelector('[data-testid="search-input"]') as HTMLInputElement;
-        searchInput?.focus();
-      },
+      action: focusSearchInput,
     },
     // Filter by status
     {
       key: "1",
       description: "未着手のみ表示",
-      action: () => {
-        const currentStatus = sp.getAll("status") as Status[];
-        const next = new URLSearchParams(sp);
-        const statusSet = new Set(currentStatus);
-
-        if (statusSet.has("not_started")) {
-          statusSet.delete("not_started");
-        } else {
-          statusSet.clear();
-          statusSet.add("not_started");
-        }
-
-        next.delete("status");
-        for (const s of statusSet) {
-          next.append("status", s);
-        }
-        setSp(next, { replace: true });
-      },
+      action: () => toggleStatusFilter("not_started"),
     },
     {
       key: "2",
       description: "進行中のみ表示",
-      action: () => {
-        const currentStatus = sp.getAll("status") as Status[];
-        const next = new URLSearchParams(sp);
-        const statusSet = new Set(currentStatus);
-
-        if (statusSet.has("in_progress")) {
-          statusSet.delete("in_progress");
-        } else {
-          statusSet.clear();
-          statusSet.add("in_progress");
-        }
-
-        next.delete("status");
-        for (const s of statusSet) {
-          next.append("status", s);
-        }
-        setSp(next, { replace: true });
-      },
+      action: () => toggleStatusFilter("in_progress"),
     },
     {
       key: "3",
       description: "完了のみ表示",
-      action: () => {
-        const currentStatus = sp.getAll("status") as Status[];
-        const next = new URLSearchParams(sp);
-        const statusSet = new Set(currentStatus);
-
-        if (statusSet.has("completed")) {
-          statusSet.delete("completed");
-        } else {
-          statusSet.clear();
-          statusSet.add("completed");
-        }
-
-        next.delete("status");
-        for (const s of statusSet) {
-          next.append("status", s);
-        }
-        setSp(next, { replace: true });
-      },
+      action: () => toggleStatusFilter("completed"),
     },
     {
       key: "0",


### PR DESCRIPTION
## 概要

コード品質を向上させるため、以下の3つの改善を実施しました：
1. マジックナンバーの定数化
2. 重複コードの削減
3. TaskDrawerコンポーネントの分割

## 実装内容

### 1. マジックナンバーの定数化

**[useKeyboardShortcuts.ts](frontend/src/hooks/useKeyboardShortcuts.ts#L5)**

```typescript
/** キーシーケンス入力のリセットまでの時間（ミリ秒） */
const SEQUENCE_RESET_TIMEOUT_MS = 1000;
```

- `setTimeout(..., 1000)` が何の意味か不明だった箇所を定数化
- コメントで意図を明確化

### 2. 重複コードの削減（DRY原則の適用）

**[TaskList.tsx](frontend/src/pages/TaskList.tsx#L30-L47)**

**Before（約70行）:**
- ステータスフィルター切り替えロジックが3箇所で重複
- 検索フォーカス処理が2箇所で重複

**After（約40行）:**
```typescript
// ヘルパー関数で統一化
const toggleStatusFilter = (targetStatus: Status) => {
  const currentStatus = sp.getAll("status") as Status[];
  const next = new URLSearchParams(sp);
  const statusSet = new Set(currentStatus);

  if (statusSet.has(targetStatus)) {
    statusSet.delete(targetStatus);
  } else {
    statusSet.clear();
    statusSet.add(targetStatus);
  }

  next.delete("status");
  for (const s of statusSet) {
    next.append("status", s);
  }
  setSp(next, { replace: true });
};

const focusSearchInput = () => {
  const searchInput = document.querySelector('[data-testid="search-input"]') as HTMLInputElement;
  searchInput?.focus();
};

// ショートカット定義がシンプルに
{
  key: "1",
  description: "未着手のみ表示",
  action: () => toggleStatusFilter("not_started"),
}
```

**効果:**
- **約43%のコード削減**（70行 → 40行）
- 保守性の向上（修正が1箇所で済む）
- 可読性の向上（ロジックが明確）

### 3. TaskDrawerコンポーネントの分割

**新規作成: [TaskChildForm.tsx](frontend/src/features/drawer/TaskChildForm.tsx)**

365行の大きなコンポーネント（TaskDrawerInner）から、子タスク作成フォームを独立したコンポーネントとして分割しました。

**TaskChildForm の責務:**
- 子タスクのタイトル・期限入力
- バリデーション
- 作成処理とエラーハンドリング
- 作成成功時のコールバック

**Props:**
```typescript
type Props = {
  taskId: number;
  onSuccess: () => void;
};
```

**[TaskDrawer.tsx](frontend/src/features/drawer/TaskDrawer.tsx#L262) での使用:**
```typescript
{/* 子タスク作成フォーム */}
<TaskChildForm taskId={taskId} onSuccess={refetch} />
```

**効果:**
- TaskDrawerInner: 365行 → 305行（**約16%削減**）
- useState の数: 9個 → 6個（childTitle, childDue, creating を削減）
- 不要なimportを削除
- 単一責任原則の適用
- テストしやすさの向上

## 改善効果のまとめ

### ✅ 保守性の向上
- コンポーネントが小さく理解しやすい
- 修正箇所が明確（責務が分離）
- DRY原則により、変更が1箇所で済む

### ✅ 可読性の向上
- マジックナンバーの排除で意図が明確
- 重複コードの削減でノイズが減少
- ヘルパー関数により処理の意図が明確

### ✅ 再利用性の向上
- TaskChildForm は他の箇所でも利用可能
- toggleStatusFilter は汎用的なパターン

### ✅ テストしやすさの向上
- 小さなコンポーネントは単体テストが容易
- ヘルパー関数も独立してテスト可能
- 責務が明確でモックしやすい

## テスト結果

✅ **全75テスト成功** - 既存機能に影響なし

```
Test Files  5 passed (5)
Tests       75 passed (75)
Duration    2.98s
```

## 影響範囲

**修正ファイル数:** 3ファイル
- [hooks/useKeyboardShortcuts.ts](frontend/src/hooks/useKeyboardShortcuts.ts)
- [pages/TaskList.tsx](frontend/src/pages/TaskList.tsx)
- [features/drawer/TaskDrawer.tsx](frontend/src/features/drawer/TaskDrawer.tsx)

**新規ファイル数:** 1ファイル
- [features/drawer/TaskChildForm.tsx](frontend/src/features/drawer/TaskChildForm.tsx)

**コード削減量:**
- TaskList.tsx: 約70行 → 40行（約30行削減）
- TaskDrawer.tsx: 約365行 → 305行（約60行削減）
- **合計: 約90行のコード削減**

## チェックリスト

- [x] マジックナンバーの定数化
- [x] 重複コードの削減
- [x] TaskDrawerコンポーネントの分割
- [x] テストの実行・成功確認
- [x] コミットメッセージの作成
- [x] PRの作成

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)